### PR TITLE
FIX: Repair SLURMClusters with Python execs in user homes

### DIFF
--- a/syncopy/shared/dask_helpers.py
+++ b/syncopy/shared/dask_helpers.py
@@ -4,7 +4,7 @@
 # 
 # Created: 2019-05-22 12:38:16
 # Last modified by: Stefan Fuertinger [stefan.fuertinger@esi-frankfurt.de]
-# Last modification time: <2020-03-12 10:19:28>
+# Last modification time: <2020-04-27 13:47:34>
 
 # Builtin/3rd party package imports
 import os
@@ -229,6 +229,11 @@ def esi_cluster_setup(partition="8GBS", n_jobs=2, mem_per_job=None,
             io_parser(slurm_wdir, varname="slurmWorkingDirectory", isfile=False)
         except Exception as exc:
             raise exc
+        
+    # Hotfix for upgraded cluster-nodes: point to correct Python executable if working from /home
+    pyExec = sys.executable
+    if sys.executable.startswith("/home"):
+        pyExec = "/mnt/gs" + sys.executable
 
     # Create `SLURMCluster` object using provided parameters
     out_files = os.path.join(slurm_wdir, "slurm-%j.out")
@@ -238,6 +243,7 @@ def esi_cluster_setup(partition="8GBS", n_jobs=2, mem_per_job=None,
                            local_directory=slurm_wdir,
                            queue=partition,
                            name="spycluster",
+                           python=pyExec,
                            job_extra=["--output={}".format(out_files)])
                            # interface="asdf", # interface is set via `psutil.net_if_addrs()`
                            # job_extra=["--hint=nomultithread",


### PR DESCRIPTION
- on the upgraded cluster nodes, the symlink /home -> /mnt/gs/home
  does not exist any more. Thus, if `sys.executable` is located
  somewhere in /home, SLURM will complain that `/home/path/to/python`
  does not exist ("No such file or directory"). This has been fixed
  by specifically pointing to /mnt/gs/home if python is running
  from within a user's /home directory.

Changes to be committed:
	modified:   syncopy/shared/dask_helpers.py

Author Guidelines
-----------------
- [X] Is the change set **< 400 lines**?
- [X] Was the code checked for memory leaks/performance bottlenecks?
- [X] Is the code running locally **and** on the ESI cluster?
~- [ ] Is the code running on all supported platforms?~ **N/A**

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do **parallel** loops have a set length and correct termination conditions?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [ ] Code layout
  - [ ] Is the code PEP8 compliant?
  - [ ] Does the code adhere to agreed-upon naming conventions?
  - [ ] Are keywords clearly named and easy to understand?
  - [ ] No commented-out code?
  - [ ] Is a file header present/properly updated?
- [ ] Are all docstrings complete and accurate?
