### PR TITLE
FIX: Modify stacking logic in ComputationalRoutine

### DIFF
--- a/syncopy/connectivity/connectivity_analysis.py
+++ b/syncopy/connectivity/connectivity_analysis.py
@@ -43,7 +43,7 @@ __all__ = ["connectivityanalysis"]
 def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                          foi=None, foilim=None, pad_to_length=None,
                          polyremoval=None, taper="hann", tapsmofrq=None,
-                         nTaper=None, toi="all", out=None, 
+                         nTaper=None, toi="all", out=None,
                          **kwargs):
 
     """
@@ -130,15 +130,15 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         nSamples = int(lenTrials.min())
 
     # --- Basic foi sanitization ---
-    
+
     foi, foilim = validate_foi(foi, foilim, data.samplerate)
 
     # only now set foi array for foilim in 1Hz steps
     if foilim:
         foi = np.arange(foilim[0], foilim[1] + 1)
-        
+
     # --- Settingn up specific Methods ---
-    
+
     if method ==  'coh':
 
         if foi is None and foilim is None:
@@ -149,7 +149,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
             SPYInfo(msg)
             foi = freqs
 
-        # sanitize taper selection and retrieve dpss settings 
+        # sanitize taper selection and retrieve dpss settings
         taper_opt = validate_taper(taper,
                                    tapsmofrq,
                                    nTaper,
@@ -157,7 +157,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                                    foimax=foi.max(),
                                    samplerate=data.samplerate,
                                    nSamples=nSamples,
-                                   output="pow") # ST_CSD's always have this unit/norm        
+                                   output="pow") # ST_CSD's always have this unit/norm
 
         # parallel computation over trials
         st_compRoutine = ST_CrossSpectra(samplerate=data.samplerate,
@@ -167,10 +167,10 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                                          polyremoval=polyremoval,
                                          timeAxis=timeAxis,
                                          foi=foi)
-        
+
         # hard coded as class attribute
         st_dimord = ST_CrossSpectra.dimord
-        
+
         # final normalization after trial averaging
         av_compRoutine = NormalizeCrossSpectra(output=output)
 
@@ -183,9 +183,9 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                                             timeAxis=timeAxis)
         # hard coded as class attribute
         st_dimord = ST_CrossCovariance.dimord
-        
+
         av_compRoutine = NormalizeCrossCov()
-        
+
     # -------------------------------------------------
     # Call the chosen single trial ComputationalRoutine
     # -------------------------------------------------
@@ -196,23 +196,24 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
 
     # Perform the trial-parallelized computation of the matrix quantity
     st_compRoutine.initialize(data,
+                              st_out.dimord,
                               chan_per_worker=None, # no parallelisation over channel possible
-                              keeptrials=keeptrials) # we need trial averaging!    
+                              keeptrials=keeptrials) # we need trial averaging!
     st_compRoutine.compute(data, st_out, parallel=kwargs.get("parallel"), log_dict={})
 
     # for debugging ccov
-    # print(5*'#',' after st_compRoutine call! ', 5*'#')  
-    # print(st_out)    
+    # print(5*'#',' after st_compRoutine call! ', 5*'#')
+    # print(st_out)
     # print(st_out.trialdefinition)
     # print(len(st_out.trials))
     # print(st_out.sampleinfo)
     # return st_out
-    
+
     # ----------------------------------------------------------------------------------
     # Sanitize output and call the chosen ComputationalRoutine on the averaged ST output
     # ----------------------------------------------------------------------------------
 
-    # If provided, make sure output object is appropriate    
+    # If provided, make sure output object is appropriate
     if out is not None:
         try:
             data_parser(out, varname="out", writable=True, empty=True,
@@ -225,8 +226,8 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         out = CrossSpectralData(dimord=st_dimord)
         new_out = True
 
-    # now take the trial average from the single trial CR as input 
-    av_compRoutine.initialize(st_out, chan_per_worker=None)
+    # now take the trial average from the single trial CR as input
+    av_compRoutine.initialize(st_out, out.dimord, chan_per_worker=None)
     av_compRoutine.pre_check() # make sure we got a trial_average
     av_compRoutine.compute(st_out, out, parallel=False)
 

--- a/syncopy/connectivity/connectivity_analysis.py
+++ b/syncopy/connectivity/connectivity_analysis.py
@@ -196,7 +196,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
 
     # Perform the trial-parallelized computation of the matrix quantity
     st_compRoutine.initialize(data,
-                              st_out.dimord,
+                              st_out._stackingDim,
                               chan_per_worker=None, # no parallelisation over channel possible
                               keeptrials=keeptrials) # we need trial averaging!
     st_compRoutine.compute(data, st_out, parallel=kwargs.get("parallel"), log_dict={})
@@ -227,7 +227,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         new_out = True
 
     # now take the trial average from the single trial CR as input
-    av_compRoutine.initialize(st_out, out.dimord, chan_per_worker=None)
+    av_compRoutine.initialize(st_out, out._stackingDim, chan_per_worker=None)
     av_compRoutine.pre_check() # make sure we got a trial_average
     av_compRoutine.compute(st_out, out, parallel=False)
 

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -111,8 +111,11 @@ class BaseData(ABC):
 
     @property
     def _stackingDim(self):
-        if self._stackingDimLabel is not None and self.dimord is not None:
-            return self.dimord.index(self._stackingDimLabel)
+        if any(["DiscreteData" in str(base) for base in self.__class__.__mro__]):
+            return 0
+        else:
+            if self._stackingDimLabel is not None and self.dimord is not None:
+                return self.dimord.index(self._stackingDimLabel)
 
     @property
     def cfg(self):

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -70,6 +70,7 @@ class BaseData(ABC):
 
     # Dummy allocations of class attributes that are actually initialized in subclasses
     _mode = None
+    _stackingDimLabel = None
 
     # Set caller for `SPYWarning` to not have it show up as '<module>'
     _spwCaller = "BaseData.{}"
@@ -107,6 +108,11 @@ class BaseData(ABC):
     @abstractmethod
     def _defaultDimord(cls):
         return NotImplementedError
+
+    @property
+    def _stackingDim(self):
+        if self._stackingDimLabel is not None and self.dimord is not None:
+            return self.dimord.index(self._stackingDimLabel)
 
     @property
     def cfg(self):
@@ -353,11 +359,11 @@ class BaseData(ABC):
             return
 
         # this enforces the _defaultDimord
-        # if set(dims) != set(self._defaultDimord):
-        #     base = "dimensional labels {}"
-        #     lgl = base.format("'" + "' x '".join(str(dim) for dim in self._defaultDimord) + "'")
-        #     act = base.format("'" + "' x '".join(str(dim) for dim in dims) + "'")
-        #     raise SPYValueError(legal=lgl, varname="dimord", actual=act)
+        if set(dims) != set(self._defaultDimord):
+            base = "dimensional labels {}"
+            lgl = base.format("'" + "' x '".join(str(dim) for dim in self._defaultDimord) + "'")
+            act = base.format("'" + "' x '".join(str(dim) for dim in dims) + "'")
+            raise SPYValueError(legal=lgl, varname="dimord", actual=act)
 
         # this enforces that custom dimords are set for every axis
         if len(dims) != len(self._defaultDimord):

--- a/syncopy/datatype/continuous_data.py
+++ b/syncopy/datatype/continuous_data.py
@@ -413,6 +413,7 @@ class AnalogData(ContinuousData):
 
     _infoFileProperties = ContinuousData._infoFileProperties + ("_hdr",)
     _defaultDimord = ["time", "channel"]
+    _stackingDimLabel = "time"
 
     # Attach plotting routines to not clutter the core module code
     singlepanelplot = _plot_analog.singlepanelplot
@@ -521,6 +522,7 @@ class SpectralData(ContinuousData):
 
     _infoFileProperties = ContinuousData._infoFileProperties + ("taper", "freq",)
     _defaultDimord = ["time", "taper", "freq", "channel"]
+    _stackingDimLabel = "time"
 
     # Attach plotting routines to not clutter the core module code
     singlepanelplot = _plot_spectral.singlepanelplot
@@ -663,6 +665,7 @@ class CrossSpectralData(ContinuousData):
 
     _infoFileProperties = ContinuousData._infoFileProperties + ("freq",)
     _defaultDimord = ["time", "freq", "channel_i", "channel_j"]
+    _stackingDimLabel = "time"
     _channel_i = None
     _channel_j = None
     _samplerate = None

--- a/syncopy/datatype/continuous_data.py
+++ b/syncopy/datatype/continuous_data.py
@@ -128,10 +128,9 @@ class ContinuousData(BaseData, ABC):
     @property
     def _shapes(self):
         if self.sampleinfo is not None:
-            sid = self.dimord.index("time")
             shp = [list(self.data.shape) for k in range(self.sampleinfo.shape[0])]
             for k, sg in enumerate(self.sampleinfo):
-                shp[k][sid] = sg[1] - sg[0]
+                shp[k][self._stackingDim] = sg[1] - sg[0]
             return [tuple(sp) for sp in shp]
 
     @property
@@ -225,8 +224,7 @@ class ContinuousData(BaseData, ABC):
     # Helper function that grabs a single trial
     def _get_trial(self, trialno):
         idx = [slice(None)] * len(self.dimord)
-        sid = self.dimord.index("time")
-        idx[sid] = slice(int(self.sampleinfo[trialno, 0]), int(self.sampleinfo[trialno, 1]))
+        idx[self._stackingDim] = slice(int(self.sampleinfo[trialno, 0]), int(self.sampleinfo[trialno, 1]))
         return self._data[tuple(idx)]
 
     def _is_empty(self):
@@ -257,11 +255,10 @@ class ContinuousData(BaseData, ABC):
         """
         shp = list(self.data.shape)
         idx = [slice(None)] * len(self.dimord)
-        tidx = self.dimord.index("time")
         stop = int(self.sampleinfo[trialno, 1])
         start = int(self.sampleinfo[trialno, 0])
-        shp[tidx] = stop - start
-        idx[tidx] = slice(start, stop)
+        shp[self._stackingDim] = stop - start
+        idx[self._stackingDim] = slice(start, stop)
 
         # process existing data selections
         if self._selection is not None:
@@ -281,16 +278,16 @@ class ContinuousData(BaseData, ABC):
                 # account for trial offsets an compute slicing index + shape
                 start = start + tstart
                 stop = start + (tstop - tstart)
-                idx[tidx] = slice(start, stop)
-                shp[tidx] = stop - start
+                idx[self._stackingDim] = slice(start, stop)
+                shp[self._stackingDim] = stop - start
 
             else:
-                idx[tidx] = [tp + start for tp in tsel]
-                shp[tidx] = len(tsel)
+                idx[self._stackingDim] = [tp + start for tp in tsel]
+                shp[self._stackingDim] = len(tsel)
 
             # process the rest
             dims = list(self.dimord)
-            dims.pop(dims.index("time"))
+            dims.pop(self._stackingDim)
             for dim in dims:
                 sel = getattr(self._selection, dim)
                 if sel:

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -342,6 +342,7 @@ class SpikeData(DiscreteData):
     _infoFileProperties = DiscreteData._infoFileProperties + ("channel", "unit",)
     _hdfFileAttributeProperties = DiscreteData._hdfFileAttributeProperties + ("channel",)
     _defaultDimord = ["sample", "channel", "unit"]
+    _stackingDimLabel = "sample"
 
     @property
     def channel(self):
@@ -521,6 +522,7 @@ class EventData(DiscreteData):
     """
 
     _defaultDimord = ["sample", "eventid"]
+    _stackingDimLabel = "sample"
 
     @property
     def eventid(self):

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -293,7 +293,7 @@ def selectdata(data, trials=None, channels=None, toi=None, toilim=None, foi=None
 
     # Fire up `ComputationalRoutine`-subclass to do the actual selecting/copying
     selectMethod = DataSelection()
-    selectMethod.initialize(data, chan_per_worker=kwargs.get("chan_per_worker"))
+    selectMethod.initialize(data, out.dimord, chan_per_worker=kwargs.get("chan_per_worker"))
     selectMethod.compute(data, out, parallel=kwargs.get("parallel"),
                          log_dict=actualSelection)
 

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -293,7 +293,7 @@ def selectdata(data, trials=None, channels=None, toi=None, toilim=None, foi=None
 
     # Fire up `ComputationalRoutine`-subclass to do the actual selecting/copying
     selectMethod = DataSelection()
-    selectMethod.initialize(data, out.dimord, chan_per_worker=kwargs.get("chan_per_worker"))
+    selectMethod.initialize(data, out._stackingDim, chan_per_worker=kwargs.get("chan_per_worker"))
     selectMethod.compute(data, out, parallel=kwargs.get("parallel"),
                          log_dict=actualSelection)
 

--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -26,7 +26,7 @@ if sys.platform == "win32":
 # Local imports
 from .tools import get_defaults
 from syncopy import __storage__, __acme__, __path__
-from syncopy.shared.errors import SPYValueError, SPYWarning, SPYParallelError
+from syncopy.shared.errors import SPYValueError, SPYTypeError, SPYParallelError, SPYWarning
 if __acme__:
     from acme import ParallelMap
     import dask.distributed as dd
@@ -226,7 +226,7 @@ class ComputationalRoutine(ABC):
         self._callMax = 10000
         self._callCount = 0
 
-    def initialize(self, data, chan_per_worker=None, keeptrials=True):
+    def initialize(self, data, out_dimord, chan_per_worker=None, keeptrials=True):
         """
         Perform dry-run of calculation to determine output shape
 
@@ -235,6 +235,8 @@ class ComputationalRoutine(ABC):
         data : syncopy data object
            Syncopy data object to be processed (has to be the same object
            that is passed to :meth:`compute` for the actual calculation).
+        out_dimord : list
+           Data dimension labels of output object
         chan_per_worker : None or int
            Number of channels to be processed by each worker (only relevant in
            case of concurrent processing). If `chan_per_worker` is `None` (default)
@@ -291,17 +293,34 @@ class ComputationalRoutine(ABC):
             dtp_list.append(dtype)
             trials.append(trial)
 
+        # Determine trial stacking dimension and compute aggregate shape of output
+        if "time" in out_dimord:        # AnalogData + SpectralData + CrossSpectralData
+            stackingDim = out_dimord.index("time")
+        elif "lag" in out_dimord:       # CrossSpectralData
+            stackingDim = out_dimord.index("lag")
+        elif "sample" in out_dimord:    # SpikeData + EventData
+            stackingDim = out_dimord.index("sample")
+        else:
+            msg = "output object with dimord containing valid stacking dimension"
+            raise SPYTypeError(out_dimord, varname="out_dimord", expected=msg)
+        totalSize = sum(cShape[stackingDim] for cShape in chk_list)
+        outputShape = list(chunkShape)
+        outputShape[stackingDim] = totalSize
+
         # The aggregate shape is computed as max across all chunks
         chk_arr = np.array(chk_list)
-        if np.unique(chk_arr[:, 0]).size > 1 and not self.keeptrials:
+        chunkShape = tuple(chk_arr.max(axis=0))
+        if np.unique(chk_arr[:, stackingDim]).size > 1 and not self.keeptrials:
+            import pdb; pdb.set_trace()
             err = "Averaging trials of unequal lengths in output currently not supported!"
             raise NotImplementedError(err)
         if np.any([dtp_list[0] != dtp for dtp in dtp_list]):
             lgl = "unique output dtype"
             act = "{} different output dtypes".format(np.unique(dtp_list).size)
             raise SPYValueError(legal=lgl, varname="dtype", actual=act)
-        chunkShape = tuple(chk_arr.max(axis=0))
-        self.outputShape = (chk_arr[:, 0].sum(),) + chunkShape[1:]
+
+        # Save determined shapes and data type
+        self.outputShape = tuple(outputShape)
         self.cfg["chunkShape"] = chunkShape
         self.dtype = np.dtype(dtp_list[0])
 
@@ -383,18 +402,15 @@ class ComputationalRoutine(ABC):
             sourceLayout.append(trial.idx)
 
         # Construct dimensional layout of output
-        # FIXME: should be targetLayout[0][stackingDim].stop
-        # FIXME: should be lyt[stackingDim] = slice(stacking, stacking + chkshp[stackingDim])
-        # FIXME: should be stacking += chkshp[stackingDim]
-        stacking = targetLayout[0][0].stop
+        stacking = targetLayout[0][stackingDim].stop
         for tk in range(1, self.numTrials):
             trial = trials[tk]
             trlArg = tuple(arg[tk] if isinstance(arg, Sized) and len(arg) == self.numTrials \
                 else arg for arg in self.argv)
             chkshp = chk_list[tk]
             lyt = [slice(0, stop) for stop in chkshp]
-            lyt[0] = slice(stacking, stacking + chkshp[0])
-            stacking += chkshp[0]
+            lyt[stackingDim] = slice(stacking, stacking + chkshp[stackingDim])
+            stacking += chkshp[stackingDim]
             if chan_per_worker is None:
                 targetLayout.append(tuple(lyt))
                 targetShapes.append(tuple([slc.stop - slc.start for slc in lyt]))

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -32,7 +32,7 @@ from .wavelet import get_optimal_wavelet_scales
 # Local imports
 from .const_def import (
     availableWavelets,
-    availableMethods,    
+    availableMethods,
 )
 
 from .compRoutines import (
@@ -198,7 +198,7 @@ def freqanalysis(data, method='mtmfft', output='fourier',
         Order of polynomial used for de-trending data in the time domain prior
         to spectral analysis. A value of 0 corresponds to subtracting the mean
         ("de-meaning"), ``polyremoval = 1`` removes linear trends (subtracting the
-        least squares fit of a linear polynomial). 
+        least squares fit of a linear polynomial).
         If `polyremoval` is `None`, no de-trending is performed. Note that
         for spectral estimation de-meaning is very advisable and hence also the
         default.
@@ -421,7 +421,7 @@ def freqanalysis(data, method='mtmfft', output='fourier',
 
     # Shortcut to data sampling interval
     dt = 1 / data.samplerate
-    
+
     foi, foilim = validate_foi(foi, foilim, data.samplerate)
 
     # see also https://docs.obspy.org/_modules/obspy/signal/detrend.html#polynomial
@@ -553,7 +553,7 @@ def freqanalysis(data, method='mtmfft', output='fourier',
             act = "empty frequency selection"
             raise SPYValueError(legal=lgl, varname="foi/foilim", actual=act)
 
-        # sanitize taper selection and retrieve dpss settings 
+        # sanitize taper selection and retrieve dpss settings
         taper_opt = validate_taper(taper,
                                   tapsmofrq,
                                   nTaper,
@@ -579,7 +579,7 @@ def freqanalysis(data, method='mtmfft', output='fourier',
         # method specific parameters
         method_kwargs = {
             'samplerate' : data.samplerate,
-            'taper' : taper,            
+            'taper' : taper,
             'taper_opt' : taper_opt
         }
 
@@ -598,7 +598,7 @@ def freqanalysis(data, method='mtmfft', output='fourier',
     elif method == "mtmconvol":
 
         _check_effective_parameters(MultiTaperFFTConvol, defaults, lcls)
-        
+
         # Process `toi` for sliding window multi taper fft,
         # we have to account for three scenarios: (1) center sliding
         # windows on all samples in (selected) trials (2) `toi` was provided as
@@ -906,7 +906,7 @@ def freqanalysis(data, method='mtmfft', output='fourier',
             postSelect,
             toi=toi,
             timeAxis=timeAxis,
-            polyremoval=polyremoval,            
+            polyremoval=polyremoval,
             output_fmt=output,
             method_kwargs=method_kwargs)
 
@@ -929,6 +929,7 @@ def freqanalysis(data, method='mtmfft', output='fourier',
 
     # Perform actual computation
     specestMethod.initialize(data,
+                             out.dimord,
                              chan_per_worker=kwargs.get("chan_per_worker"),
                              keeptrials=keeptrials)
     specestMethod.compute(data, out, parallel=kwargs.get("parallel"), log_dict=log_dct)

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -929,7 +929,7 @@ def freqanalysis(data, method='mtmfft', output='fourier',
 
     # Perform actual computation
     specestMethod.initialize(data,
-                             out.dimord,
+                             out._stackingDim,
                              chan_per_worker=kwargs.get("chan_per_worker"),
                              keeptrials=keeptrials)
     specestMethod.compute(data, out, parallel=kwargs.get("parallel"), log_dict=log_dct)

--- a/syncopy/tests/spy_setup.py
+++ b/syncopy/tests/spy_setup.py
@@ -25,6 +25,5 @@ if __name__ == "__main__":
     # Test stuff within here...
     artdata = generate_artificial_data(nTrials=5, nChannels=16,
                                        equidistant=False, inmemory=False)
-    sys.exit()
     spec = spy.freqanalysis(artdata, method="mtmfft", taper="dpss", output="pow")
 

--- a/syncopy/tests/test_computationalroutine.py
+++ b/syncopy/tests/test_computationalroutine.py
@@ -69,7 +69,7 @@ def filter_manager(data, b=None, a=None,
         newOut = True
         out = AnalogData(dimord=AnalogData._defaultDimord)
     myfilter = LowPassFilter(b, a=a)
-    myfilter.initialize(data, out.dimord, chan_per_worker=chan_per_worker, keeptrials=keeptrials)
+    myfilter.initialize(data, out._stackingDim, chan_per_worker=chan_per_worker, keeptrials=keeptrials)
     myfilter.compute(data, out,
                      parallel=parallel,
                      parallel_store=parallel_store,

--- a/syncopy/tests/test_computationalroutine.py
+++ b/syncopy/tests/test_computationalroutine.py
@@ -64,12 +64,12 @@ class LowPassFilter(ComputationalRoutine):
 def filter_manager(data, b=None, a=None,
                    out=None, select=None, chan_per_worker=None, keeptrials=True,
                    parallel=False, parallel_store=None, log_dict=None):
-    myfilter = LowPassFilter(b, a=a)
-    myfilter.initialize(data, chan_per_worker=chan_per_worker, keeptrials=keeptrials)
     newOut = False
     if out is None:
         newOut = True
         out = AnalogData(dimord=AnalogData._defaultDimord)
+    myfilter = LowPassFilter(b, a=a)
+    myfilter.initialize(data, out.dimord, chan_per_worker=chan_per_worker, keeptrials=keeptrials)
     myfilter.compute(data, out,
                      parallel=parallel,
                      parallel_store=parallel_store,

--- a/syncopy/tests/test_specest.py
+++ b/syncopy/tests/test_specest.py
@@ -918,6 +918,7 @@ class TestWavelet():
                        "channels": range(0, int(nChannels / 2)),
                        "toilim": [-20, 60.8]}]
 
+    @skip_low_mem
     def test_wav_solution(self):
 
         # Compute TF specturm across entire time-interval (use integer-valued


### PR DESCRIPTION
- new mandatory positional argument in `initialize` of `ComputationalRoutine`:
  `out_dimord` provides the output object's dimensional labels. This is used
  to determine the correct stacking dimension for trials
- do not default to the first dimension as stacking dimension: instead use the
  new `stackingDim` variable (which is determined based on `out_dimord`, see above)
- closes #130

On branch comproutine_fix
 Changes to be committed:
	modified:   syncopy/connectivity/connectivity_analysis.py
	modified:   syncopy/datatype/methods/selectdata.py
	modified:   syncopy/shared/computational_routine.py
	modified:   syncopy/specest/freqanalysis.py
	modified:   syncopy/tests/spy_setup.py
	modified:   syncopy/tests/test_computationalroutine.py
	modified:   syncopy/tests/test_specest.py

Author Guidelines
-----------------
- [X] Is the change set **< 400 lines**?
- [X] Was the code checked for memory leaks/performance bottlenecks?
- [X] Is the code running locally **and** on the ESI cluster?
- [X] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do **parallel** loops have a set length and correct termination conditions?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [ ] Code layout
  - [ ] Is the code PEP8 compliant?
  - [ ] Does the code adhere to agreed-upon naming conventions?
  - [ ] Are keywords clearly named and easy to understand?
  - [ ] No commented-out code?
- [ ] Are all docstrings complete and accurate?
