### PR TITLE
FIX: Return correct trialtimes for SpikeData

### DIFF
--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -593,6 +593,7 @@ class BaseData(ABC):
 
     @property
     def _t0(self):
+        """ These are the trigger offsets """
         if self._trialdefinition is not None:
             return self._trialdefinition[:, 2]
         else:

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -182,9 +182,10 @@ class DiscreteData(BaseData, ABC):
     def trialtime(self):
         """list(:class:`numpy.ndarray`): trigger-relative sample times in s"""
         if self.samplerate is not None and self.sampleinfo is not None:
-            return [((t + self._t0[tk]) / self.samplerate \
-                    for t in range(0, int(self.sampleinfo[tk, 1] - self.sampleinfo[tk, 0]))) \
-                    for tk in self.trialid]
+            return [
+                (trl[:, 0] - self._t0[tk] - self.sampleinfo[tk, 0]) / self.samplerate
+                for tk, trl in enumerate(self.trials)
+            ]
 
     # Helper function that grabs a single trial
     def _get_trial(self, trialno):


### PR DESCRIPTION
- return a list of arrays with length nTrials instead of a generator with length nSpikes
- fixes #218 with the solution provided by @atlaie

Changes to be committed:
	modified:   syncopy/datatype/base_data.py
	modified:   syncopy/datatype/discrete_data.py

Author Guidelines
-----------------
- [x] Is the change set **< 400 lines**?
this is a tiny bugfix
- [ ] ~Was the code checked for memory leaks/performance bottlenecks?~
- [ ] ~Is the code running locally **and** on the ESI cluster?~
- [ ] ~Is the code running on all supported platforms?~

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do **parallel** loops have a set length and correct termination conditions?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [ ] Code layout
  - [ ] Is the code PEP8 compliant?
  - [ ] Does the code adhere to agreed-upon naming conventions?
  - [ ] Are keywords clearly named and easy to understand?
  - [ ] No commented-out code?
- [ ] Are all docstrings complete and accurate?
