### PR TITLE
NEW: Support tapers other than dpss with additional parameters

### DIFF
--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -36,8 +36,8 @@ availableMethods = ("coh", "corr", "granger")
 @detect_parallel_client
 def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                          foi=None, foilim=None, pad_to_length=None,
-                         polyremoval=None, taper="hann", taper_opt=None, tapsmofrq=None,
-                         nTaper=None, out=None, **kwargs):
+                         polyremoval=None, tapsmofrq=None, nTaper=None,
+                         taper="hann", taper_opt=None, out=None, **kwargs):
 
     """
     Perform connectivity analysis of Syncopy :class:`~syncopy.AnalogData` objects
@@ -112,22 +112,22 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         the next power of two.
         If `None` and trials have unequal lengths all trials are padded to match
         the longest trial.
-    taper : str
+    tapsmofrq : float or None
+        Only valid if `method` is `'coh'` or `'granger'`.
+        Enables multi-tapering and sets the amount of spectral
+        smoothing with slepian tapers in Hz.
+    nTaper : int or None
+        Only valid if `method` is `'coh'` or `'granger'` and `tapsmofrq` is set.
+        Number of orthogonal tapers to use for multi-tapering. It is not recommended to set the number
+        of tapers manually! Leave at `None` for the optimal number to be set automatically.
+    taper : str or None, optional
         Only valid if `method` is `'coh'` or `'granger'`. Windowing function,
         one of :data:`~syncopy.specest.const_def.availableTapers`
+        For multi-tapering with slepian tapers use `tapsmofrq` directly.
     taper_opt : dict or None
         Dictionary with keys for additional taper parameters.
         For example :func:`~scipy.signal.windows.kaiser` has
-        the additional parameter 'beta'.
-    tapsmofrq : float
-        Only valid if `method` is `'coh'` or `'granger'` and `taper` is `'dpss'`.
-        The amount of spectral smoothing through  multi-tapering (Hz).
-        Note that smoothing frequency specifications are one-sided,
-        i.e., 4 Hz smoothing means plus-minus 4 Hz, i.e., a 8 Hz smoothing box.
-    nTaper : int or None
-        Only valid if `method` is `'coh'` or `'granger'` and ``taper = 'dpss'``.
-        Number of orthogonal tapers to use. It is not recommended to set the number
-        of tapers manually! Leave at `None` for the optimal number to be set automatically.
+        the additional parameter 'beta'. For multi-tapering use `tapsmofrq` directly.
 
     Examples
     --------
@@ -227,15 +227,15 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
             foi = freqs
 
         # sanitize taper selection and retrieve dpss settings
-        taper_opt = process_taper(taper,
-                                  taper_opt,
-                                  tapsmofrq,
-                                  nTaper,
-                                  keeptapers=False,   # ST_CSD's always average tapers
-                                  foimax=foi.max(),
-                                  samplerate=data.samplerate,
-                                  nSamples=nSamples,
-                                  output="pow")   # ST_CSD's always have this unit/norm
+        taper, taper_opt = process_taper(taper,
+                                         taper_opt,
+                                         tapsmofrq,
+                                         nTaper,
+                                         keeptapers=False,   # ST_CSD's always average tapers
+                                         foimax=foi.max(),
+                                         samplerate=data.samplerate,
+                                         nSamples=nSamples,
+                                         output="pow")   # ST_CSD's always have this unit/norm
 
         log_dict["foi"] = foi
         log_dict["taper"] = taper

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -36,7 +36,7 @@ availableMethods = ("coh", "corr", "granger")
 @detect_parallel_client
 def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                          foi=None, foilim=None, pad_to_length=None,
-                         polyremoval=None, taper="hann", tapsmofrq=None,
+                         polyremoval=None, taper="hann", taper_opt=None, tapsmofrq=None,
                          nTaper=None, out=None, **kwargs):
 
     """
@@ -224,6 +224,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
 
         # sanitize taper selection and retrieve dpss settings
         taper_opt = process_taper(taper,
+                                  taper_opt,
                                   tapsmofrq,
                                   nTaper,
                                   keeptapers=False,   # ST_CSD's always average tapers
@@ -234,10 +235,11 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
 
         log_dict["foi"] = foi
         log_dict["taper"] = taper
-        # only dpss returns non-empty taper_opt dict
-        if taper_opt:
+        if taper_opt and taper == 'dpss':
             log_dict["nTaper"] = taper_opt["Kmax"]
             log_dict["tapsmofrq"] = tapsmofrq
+        elif taper_opt:
+            log_dict["taper_opt"] = taper_opt
 
         check_effective_parameters(ST_CrossSpectra, defaults, lcls)
         # parallel computation over trials

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -115,6 +115,10 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
     taper : str
         Only valid if `method` is `'coh'` or `'granger'`. Windowing function,
         one of :data:`~syncopy.specest.const_def.availableTapers`
+    taper_opt : dict or None
+        Dictionary with keys for additional taper parameters.
+        For example :func:`~scipy.signal.windows.kaiser` has
+        the additional parameter 'beta'.
     tapsmofrq : float
         Only valid if `method` is `'coh'` or `'granger'` and `taper` is `'dpss'`.
         The amount of spectral smoothing through  multi-tapering (Hz).

--- a/syncopy/shared/const_def.py
+++ b/syncopy/shared/const_def.py
@@ -22,6 +22,7 @@ spectralConversions = {"pow": lambda x: (x * np.conj(x)).real.astype(np.float32)
 all_windows = windows.__all__
 all_windows.remove("exponential")  # not symmetric
 all_windows.remove("hanning")  # deprecated
+all_windows.remove("dpss")  # activated via `tapsmofrq`
 
 availableTapers = all_windows
 availablePaddingOpt = [None, 'nextpow2']

--- a/syncopy/shared/const_def.py
+++ b/syncopy/shared/const_def.py
@@ -20,10 +20,8 @@ spectralConversions = {"pow": lambda x: (x * np.conj(x)).real.astype(np.float32)
 
 #: available tapers of :func:`~syncopy.freqanalysis` and  :func:`~syncopy.connectivity`
 all_windows = windows.__all__
-all_windows.remove("exponential") # not symmetric
-all_windows.remove("hanning") # deprecated
-all_windows.remove("gaussian") # we don't support taper with args
-all_windows.remove("kaiser") # we don't support taper with args
+all_windows.remove("exponential")  # not symmetric
+all_windows.remove("hanning")  # deprecated
 
 availableTapers = all_windows
 availablePaddingOpt = [None, 'nextpow2']

--- a/syncopy/shared/input_processors.py
+++ b/syncopy/shared/input_processors.py
@@ -4,12 +4,14 @@
 # The processors return values needed directly for the
 # downstream method calls.
 # Input args are the parameters to check for validity + auxiliary parameters
-# needed for the checks, raise exceptions in case of invalid input.
+# needed for the checks. Processors raise exceptions in case of invalid input.
 #
 
 # Builtin/3rd party package imports
 import numpy as np
 import numbers
+from inspect import signature
+from scipy.signal import windows
 
 from syncopy.shared.errors import SPYValueError, SPYWarning, SPYInfo
 from syncopy.shared.parsers import scalar_parser, array_parser
@@ -18,26 +20,26 @@ from syncopy.datatype.methods.padding import _nextpow2
 
 
 def process_padding(pad_to_length, lenTrials):
-    
+
     """
     Simplified padding interface, for all taper based methods
     padding has to be done **before** tapering!
 
     Parameters
-    ----------    
+    ----------
     pad_to_length : int, None or 'nextpow2'
-        Either an integer indicating the absolute length of 
+        Either an integer indicating the absolute length of
         the trials after padding or `'nextpow2'` to pad all trials
-        to the nearest power of two. If `None`, no padding is to 
+        to the nearest power of two. If `None`, no padding is to
         be performed
     lenTrials : sequence of int_like
         Sequence holding all individual trial lengths
 
     Returns
-    -------    
+    -------
     abs_pad : int
         Absolute length of all trials after padding
-    
+
     """
     # supported padding options
     not_valid = False
@@ -45,8 +47,8 @@ def process_padding(pad_to_length, lenTrials):
         not_valid = True
     elif isinstance(pad_to_length, str) and pad_to_length not in availablePaddingOpt:
         not_valid = True
-        # bool is an int subclass, have to check for it separately...        
-    if isinstance(pad_to_length, bool): 
+        # bool is an int subclass, have to check for it separately...
+    if isinstance(pad_to_length, bool):
         not_valid = True
     if not_valid:
         lgl = "`None`, 'nextpow2' or an integer like number"
@@ -65,14 +67,14 @@ def process_padding(pad_to_length, lenTrials):
     # or pad to optimal FFT lengths
     elif pad_to_length == 'nextpow2':
         abs_pad = _nextpow2(int(lenTrials.max()))
-        
+
     # no padding in case of equal length trials
     elif pad_to_length is None:        
         abs_pad = int(lenTrials.max())
         if lenTrials.min() != lenTrials.max():            
             msg = f"Unequal trial lengths present, padding all trials to {abs_pad} samples"
             SPYWarning(msg)
-                
+
     # `abs_pad` is now the (soon to be padded) signal length in samples
 
     return abs_pad
@@ -149,18 +151,21 @@ def process_foi(foi, foilim, samplerate):
 
 
 def process_taper(taper,
+                  taper_opt,
                   tapsmofrq,
                   nTaper,
                   keeptapers,
                   foimax,
                   samplerate,
-                   nSamples,
+                  nSamples,
                   output):
 
     """
     General taper validation and Slepian/dpss input sanitization.
-    The default is to max out `nTaper` to achieve the desired frequency
-    smoothing bandwidth. For details about the Slepion settings see
+
+    For `taper='dpss'` the default is to max out `nTaper` to achieve
+    the desired frequency smoothing bandwidth.
+    For details about the Slepion settings see
 
     "The Effective Bandwidth of a Multitaper Spectral Estimator,
     A. T. Walden, E. J. McCoy and D. B. Percival"
@@ -169,10 +174,13 @@ def process_taper(taper,
     ----------
     taper : str
         Windowing function, one of :data:`~syncopy.shared.const_def.availableTapers`
+    taper_opt : dict or None
+        Dictionary holding additional keywords for tapers which have additional
+        parameters like for example :func:`~scipy.signal.windows.kaiser`
     tapsmofrq : float or None
         Taper smoothing bandwidth for `taper='dpss'`
     nTaper : int_like or None
-        Number of tapers to use for multi-tapering (not recommended)
+        Number of tapers to use for multi-tapering with `taper='dpss'` (not recommended)
 
     Other Parameters
     ----------------
@@ -188,10 +196,11 @@ def process_taper(taper,
 
     Returns
     -------
-    dpss_opt : dict
+    taper_opt : dict
         For multi-tapering (`taper='dpss'`) contains the
         parameters `NW` and `Kmax` for `scipy.signal.windows.dpss`.
-        For all other tapers this is an empty dictionary.
+        For other tapers these are the additional parameters or
+        an empty dictionary.
     """
 
     # See if taper choice is supported
@@ -199,8 +208,13 @@ def process_taper(taper,
         lgl = "'" + "or '".join(opt + "' " for opt in availableTapers)
         raise SPYValueError(legal=lgl, varname="taper", actual=taper)
 
-    # Warn user about DPSS only settings
+    if not isinstance(taper_opt, (dict, type(None))):
+        lgl = "dict or None"
+        actual = type(taper_opt)
+        raise SPYValueError(lgl, "taper_opt", actual)
+
     if taper != "dpss":
+        # Warn user about DPSS only settings
         if tapsmofrq is not None:
             msg = "`tapsmofrq` is only used if `taper` is `dpss`!"
             SPYWarning(msg)
@@ -211,8 +225,27 @@ def process_taper(taper,
             msg = "`keeptapers` is only used if `taper` is `dpss`!"
             SPYWarning(msg)
 
-        # empty dpss_opt, only Slepians have options
-        return {}
+        if taper_opt is not None:
+            # availableTapers are given by windows.__all__
+            parameters = signature(getattr(windows, taper)).parameters
+            supported_kws = list(parameters.keys())
+            # 'M' is the kw for the window length
+            # for all of scipy's windows
+            supported_kws.remove('M')
+
+            for key in taper_opt:
+                if key not in supported_kws:
+                    lgl = f"one of {supported_kws} for `taper='{taper}'`"
+                    raise SPYValueError(lgl, "taper_opt key", key)
+            # all supplied keys are fine
+            return taper_opt
+        else:
+            # taper_opt was None
+            return {}
+
+    if taper == "dpss" and taper_opt is not None:
+        msg = "For multi-tapering with `taper='dpss'` use `tapsmofrq` and `nTaper` to control frequency smoothing, `taper_opt` has no effect"
+        SPYWarning(msg)
 
     # direct mtm estimate (averaging) only valid for spectral power
     if taper == "dpss" and not keeptapers and output != "pow":
@@ -244,16 +277,6 @@ def process_taper(taper,
             lgl = "smoothing bandwidth in Hz, typical values are in the range 1-10Hz"
             raise SPYValueError(legal=lgl, varname="tapsmofrq", actual=tapsmofrq)
 
-            # Try to derive "sane" settings by using 3/4 octave
-            # smoothing of highest `foi`
-            # following Hill et al. "Oscillatory Synchronization in Large-Scale
-            # Cortical Networks Predicts Perception", Neuron, 2011
-            # FIX ME: This "sane setting" seems quite excessive (huuuge bwidths)
-
-            # tapsmofrq = (foimax * 2**(3 / 4 / 2) - foimax * 2**(-3 / 4 / 2)) / 2
-            # msg = f'Automatic setting of `tapsmofrq` to {tapsmofrq:.2f}'
-            # SPYInfo(msg)
-
         # --------------------------------------------
         # set parameters for scipy.signal.windows.dpss
         NW = tapsmofrq * nSamples / (2 * samplerate)
@@ -266,7 +289,7 @@ def process_taper(taper,
         if nTaper is None:
             msg = f'Using {Kmax} taper(s) for multi-tapering'
             SPYInfo(msg)
-            dpss_opt = {'NW' : NW, 'Kmax' : Kmax}
+            dpss_opt = {'NW': NW, 'Kmax': Kmax}
             return dpss_opt
 
         elif nTaper is not None:
@@ -285,7 +308,7 @@ def process_taper(taper,
                 '''
                 SPYWarning(msg)
 
-            dpss_opt = {'NW' : NW, 'Kmax' : nTaper}
+            dpss_opt = {'NW': NW, 'Kmax': nTaper}
             return dpss_opt
 
 

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -165,6 +165,10 @@ def freqanalysis(data, method='mtmfft', output='pow',
     taper : str
         Only valid if `method` is `'mtmfft'` or `'mtmconvol'`. Windowing function,
         one of :data:`~syncopy.shared.const_def.availableTapers` (see below).
+    taper_opt : dict or None
+        Dictionary with keys for additional taper parameters.
+        For example :func:`~scipy.signal.windows.kaiser` has
+        the additional parameter 'beta'.
     tapsmofrq : float
         Only valid if `method` is `'mtmfft'` or `'mtmconvol'` and `taper` is `'dpss'`.
         The amount of spectral smoothing through  multi-tapering (Hz).

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -162,24 +162,25 @@ def freqanalysis(data, method='mtmfft', output='pow',
         If `polyremoval` is `None`, no de-trending is performed. Note that
         for spectral estimation de-meaning is very advisable and hence also the
         default.
-    taper : str
+    tapsmofrq : float or None
+        Only valid if `method` is `'mtmfft'` or `'mtmconvol'`
+        Enables multi-tapering and sets the amount of spectral
+        smoothing with slepian tapers in Hz.
+    nTaper : int or None
+        Only valid if `method` is `'mtmfft'` or `'mtmconvol'` and `tapsmofrq` is set.
+        Number of orthogonal tapers to use for multi-tapering. It is not recommended to set the number
+        of tapers manually! Leave at `None` for the optimal number to be set automatically.
+    taper : str or None, optional
         Only valid if `method` is `'mtmfft'` or `'mtmconvol'`. Windowing function,
-        one of :data:`~syncopy.shared.const_def.availableTapers` (see below).
+        one of :data:`~syncopy.specest.const_def.availableTapers`
+        For multi-tapering with slepian tapers use `tapsmofrq` directly.
     taper_opt : dict or None
         Dictionary with keys for additional taper parameters.
         For example :func:`~scipy.signal.windows.kaiser` has
-        the additional parameter 'beta'.
-    tapsmofrq : float
-        Only valid if `method` is `'mtmfft'` or `'mtmconvol'` and `taper` is `'dpss'`.
-        The amount of spectral smoothing through  multi-tapering (Hz).
-        Note that smoothing frequency specifications are one-sided,
-        i.e., 4 Hz smoothing means plus-minus 4 Hz, i.e., a 8 Hz smoothing box.
-    nTaper : int or None
-        Only valid if `method` is `'mtmfft'` or `'mtmconvol'` and `taper='dpss'`.
-        Number of orthogonal tapers to use. It is not recommended to set the number
-        of tapers manually! Leave at `None` for the optimal number to be set automatically.
+        the additional parameter 'beta'. For multi-tapering use `tapsmofrq` directly.
     keeptapers : bool
-        Only valid if `method` is `'mtmfft'` or `'mtmconvol'`.
+        Only valid if `method` is `'mtmfft'` or `'mtmconvol'` and multi-tapering enabled
+        via  setting `tapsmofrq`.
         If `True`, return spectral estimates for each taper.
         Otherwise power spectrum is averaged across tapers,
         if and only if `output` is `pow`.
@@ -476,15 +477,15 @@ def freqanalysis(data, method='mtmfft', output='pow',
             raise SPYValueError(legal=lgl, varname="foi/foilim", actual=act)
 
         # sanitize taper selection and/or retrieve dpss settings
-        taper_opt = process_taper(taper,
-                                  taper_opt,
-                                  tapsmofrq,
-                                  nTaper,
-                                  keeptapers,
-                                  foimax=foi.max(),
-                                  samplerate=data.samplerate,
-                                  nSamples=minSampleNum,
-                                  output=output)
+        taper, taper_opt = process_taper(taper,
+                                         taper_opt,
+                                         tapsmofrq,
+                                         nTaper,
+                                         keeptapers,
+                                         foimax=foi.max(),
+                                         samplerate=data.samplerate,
+                                         nSamples=minSampleNum,
+                                         output=output)
 
         # Update `log_dct` w/method-specific options
         log_dct["taper"] = taper

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -476,7 +476,8 @@ def run_cfg_test(call, method, positivity=True):
     cfg = get_defaults(ca)
 
     cfg.method = method
-    cfg.foilim = [0, 70]
+    if method != 'granger':
+        cfg.foilim = [0, 70]
     # test general tapers with
     # additional parameters
     cfg.taper = 'kaiser'

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -66,7 +66,7 @@ class TestGranger:
 
     def test_gr_solution(self, **kwargs):
 
-        Gcaus = ca(self.data, method='granger', taper='dpss',
+        Gcaus = ca(self.data, method='granger',
                    tapsmofrq=3, foi=self.foi, **kwargs)
 
         # check all channel combinations with coupling
@@ -180,7 +180,6 @@ class TestCoherence:
                  method='coh',
                  foilim=[5, 60],
                  output='pow',
-                 taper='dpss',
                  tapsmofrq=1.5,
                  **kwargs)
 
@@ -464,7 +463,10 @@ def run_cfg_test(call, method, positivity=True):
 
     cfg.method = method
     cfg.foilim = [0, 70]
-    cfg.taper = 'parzen'
+    # test general tapers with
+    # additional parameters
+    cfg.taper = 'kaiser'
+    cfg.taper_opt = {'beta': 2}
     cfg.output = 'abs'
 
     result = call(cfg)

--- a/syncopy/tests/test_specest.py
+++ b/syncopy/tests/test_specest.py
@@ -189,7 +189,7 @@ class TestMTMFFT():
 
         # keep trials but throw away tapers
         out = SpectralData(dimord=SpectralData._defaultDimord)
-        freqanalysis(self.adata, method="mtmfft", taper="dpss",
+        freqanalysis(self.adata, method="mtmfft",
                      tapsmofrq=3, keeptapers=False, output="pow", out=out)
         assert out.sampleinfo.shape == (self.nTrials, 2)
         assert out.taper.size == 1
@@ -197,7 +197,6 @@ class TestMTMFFT():
         # re-use `cfg` from above and additionally throw away `tapers`
         cfg.dataset = self.adata
         cfg.out = SpectralData(dimord=SpectralData._defaultDimord)
-        cfg.taper = "dpss"
         cfg.tapsmofrq = 3
         cfg.output = "pow"
         cfg.keeptapers = False
@@ -258,12 +257,12 @@ class TestMTMFFT():
 
             # ensure default setting results in single taper
             spec = freqanalysis(self.adata, method="mtmfft",
-                                taper="dpss", tapsmofrq=3,  output="pow", select=select)
+                                tapsmofrq=3, output="pow", select=select)
             assert spec.taper.size == 1
             assert spec.channel.size == len(chanList)
 
             # specify tapers
-            spec = freqanalysis(self.adata, method="mtmfft", taper="dpss",
+            spec = freqanalysis(self.adata, method="mtmfft",
                                 tapsmofrq=7, keeptapers=True, select=select)
             assert spec.channel.size == len(chanList)
 
@@ -273,7 +272,6 @@ class TestMTMFFT():
         timeAxis = artdata.dimord.index("time")
         cfg = StructDict()
         cfg.method = "mtmfft"
-        cfg.taper = "dpss"
         cfg.tapsmofrq = 9.3
         cfg.output = "pow"
 
@@ -374,7 +372,7 @@ class TestMTMFFT():
             vdata = VirtualData([dmap, dmap])
             avdata = AnalogData(vdata, samplerate=self.fs,
                                 trialdefinition=self.trialdefinition)
-            spec = freqanalysis(avdata, method="mtmfft", taper="dpss",
+            spec = freqanalysis(avdata, method="mtmfft",
                                 tapsmofrq=3, keeptapers=False, output="abs", pad="relative",
                                 padlength=npad)
             assert (np.diff(avdata.sampleinfo)[0][0] + npad) / 2 + 1 == spec.freq.size
@@ -397,7 +395,6 @@ class TestMTMFFT():
         # now create uniform `cfg` for remaining SLURM tests
         cfg = StructDict()
         cfg.method = "mtmfft"
-        cfg.taper = "dpss"
         cfg.tapsmofrq = 9.3
         cfg.output = "pow"
 
@@ -535,7 +532,7 @@ class TestMTMConvol():
 
         # keep trials but throw away tapers
         out = SpectralData(dimord=SpectralData._defaultDimord)
-        freqanalysis(self.tfData, method="mtmconvol", taper="dpss", tapsmofrq=3,
+        freqanalysis(self.tfData, method="mtmconvol", tapsmofrq=3,
                      keeptapers=False, output="pow", toi=0.0, t_ftimwin=1.0,
                      out=out)
         assert out.sampleinfo.shape == (self.nTrials, 2)
@@ -544,7 +541,6 @@ class TestMTMConvol():
         # re-use `cfg` from above and additionally throw away `tapers`
         cfg.dataset = self.tfData
         cfg.out = SpectralData(dimord=SpectralData._defaultDimord)
-        cfg.taper = "dpss"
         cfg.tapsmofrq = 3
         cfg.keeptapers = False
         cfg.output = "pow"
@@ -696,7 +692,6 @@ class TestMTMConvol():
 
         # Test correct time-array assembly for ``toi = "all"`` (cut down data signifcantly
         # to not overflow memory here); same for ``toi = 1.0```
-        cfg.taper = "dpss"
         cfg.tapsmofrq = 10
         cfg.keeptapers = True
         cfg.select = {"trials": [0], "channels": [0], "toilim": [-0.5, 0.5]}
@@ -737,7 +732,6 @@ class TestMTMConvol():
         # also make sure ``toi = "all"`` works under any circumstance
         cfg = get_defaults(freqanalysis)
         cfg.method = "mtmconvol"
-        cfg.taper = "dpss"
         cfg.tapsmofrq = 10
         cfg.t_ftimwin = 1.0
         cfg.output = "pow"
@@ -848,7 +842,6 @@ class TestMTMConvol():
 
         # equidistant trial spacing, keep tapers
         cfg.output = "abs"
-        cfg.taper = "dpss"
         cfg.tapsmofrq = 10
         cfg.keeptapers = True
         artdata = generate_artificial_data(nTrials=self.nTrials, nChannels=self.nChannels,


### PR DESCRIPTION
- tapers like 'kaiser' need additional parameters which now can be
passed from the fronted via the new `taper_opt` parameter
- no changes in backend needed as here a `taper_opt` was already present
- resolves #183

On branch general_tapers
Changes to be committed:
	modified:   syncopy/nwanalysis/connectivity_analysis.py
	modified:   syncopy/shared/const_def.py
	modified:   syncopy/shared/input_processors.py
	modified:   syncopy/specest/freqanalysis.py

Author Guidelines
-----------------
- [x] Is the change set **< 400 lines**?
The introduced changes can't effect any of those points
- [ ] Was the code checked for memory leaks/performance bottlenecks?
- [ ] Is the code running locally **and** on the ESI cluster?
- [ ] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do **parallel** loops have a set length and correct termination conditions?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [ ] Code layout
  - [ ] Is the code PEP8 compliant?
  - [ ] Does the code adhere to agreed-upon naming conventions?
  - [ ] Are keywords clearly named and easy to understand?
  - [ ] No commented-out code?
- [ ] Are all docstrings complete and accurate?
