### PR TITLE
CHG: Demeaning after tapering (only) for Granger and additional front…

### DIFF
--- a/syncopy/nwanalysis/ST_compRoutines.py
+++ b/syncopy/nwanalysis/ST_compRoutines.py
@@ -27,6 +27,7 @@ def cross_spectra_cF(trl_dat,
                      foi=None,
                      taper="hann",
                      taper_opt=None,
+                     demean_taper=False,
                      polyremoval=False,
                      timeAxis=0,
                      chunkShape=None,
@@ -77,6 +78,8 @@ def cross_spectra_cF(trl_dat,
         `'Kmax'` and `'NW'`.
         For further details, please refer to the
         `SciPy docs <https://docs.scipy.org/doc/scipy/reference/signal.windows.html>`_
+    demean_taper : bool
+        Set to `True` to perform de-meaning after tapering
     polyremoval : int or None
         Order of polynomial used for de-trending data in the time domain prior
         to spectral analysis. A value of 0 corresponds to subtracting the mean
@@ -153,7 +156,7 @@ def cross_spectra_cF(trl_dat,
         dat = detrend(dat, type='linear', axis=0, overwrite_data=True)
 
     CS_ij = csd(dat, samplerate, nSamples, taper=taper, taper_opt=taper_opt)
-    
+
     # where does freqs go/come from -
     # we will eventually solve this issue..
     return CS_ij[None, freq_idx, ...]

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -254,17 +254,12 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
 
         check_effective_parameters(ST_CrossSpectra, defaults, lcls)
 
-        if method == 'granger':
-            demean_taper = True
-        else:
-            demean_taper = False
-
         # parallel computation over trials
         st_compRoutine = ST_CrossSpectra(samplerate=data.samplerate,
                                          nSamples=nSamples,
                                          taper=taper,
                                          taper_opt=taper_opt,
-                                         demean_taper=demean_taper,
+                                         demean_taper=(method == 'granger'),
                                          polyremoval=polyremoval,
                                          timeAxis=timeAxis,
                                          foi=foi)

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -195,6 +195,19 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                 "pad_to_length": pad_to_length}
 
     # --- Setting up specific Methods ---
+    if method == 'granger':
+
+        if foi is not None or foilim is not None:
+            lgl = "no foi specification for Granger analysis"
+            actual = "foi or foilim specification"
+            raise SPYValueError(lgl, 'foi/foilim', actual)
+
+        nChannels = len(data.channel)
+        nTrials = len(lenTrials)
+        # warn user if this ratio is not small
+        if nChannels / nTrials > 0.1:
+            msg = "Multi-channel Granger analysis can be numerically unstable, it is recommended to have at least 10 times the number of trials compared to the number of channels. Try calculating in sub-groups of fewer channels!"
+            SPYWarning(msg)
 
     if method in ['coh', 'granger']:
 
@@ -240,11 +253,18 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
             log_dict["tapsmofrq"] = tapsmofrq
 
         check_effective_parameters(ST_CrossSpectra, defaults, lcls)
+
+        if method == 'granger':
+            demean_taper = True
+        else:
+            demean_taper = False
+
         # parallel computation over trials
         st_compRoutine = ST_CrossSpectra(samplerate=data.samplerate,
                                          nSamples=nSamples,
                                          taper=taper,
                                          taper_opt=taper_opt,
+                                         demean_taper=demean_taper,
                                          polyremoval=polyremoval,
                                          timeAxis=timeAxis,
                                          foi=foi)

--- a/syncopy/nwanalysis/csd.py
+++ b/syncopy/nwanalysis/csd.py
@@ -19,6 +19,7 @@ def csd(trl_dat,
         nSamples=None,
         taper="hann",
         taper_opt=None,
+        demean_taper=False,
         norm=False,
         fullOutput=False):
 
@@ -62,6 +63,8 @@ def csd(trl_dat,
         `'Kmax'` and `'NW'`.
         For further details, please refer to the
         `SciPy docs <https://docs.scipy.org/doc/scipy/reference/signal.windows.html>`_
+    demean_taper : bool
+        Set to `True` to perform de-meaning after tapering
     norm : bool, optional
         Set to `True` to normalize for a single-trial coherence measure.
         Only meaningful in a multi-taper (``taper = "dpss"``) setup and if no
@@ -91,7 +94,7 @@ def csd(trl_dat,
 
     # compute the individual spectra
     # specs have shape (nTapers x nFreq x nChannels)
-    specs, freqs = mtmfft(trl_dat, samplerate, nSamples, taper, taper_opt)
+    specs, freqs = mtmfft(trl_dat, samplerate, nSamples, taper, taper_opt, demean_taper)
 
     # outer product along channel axes
     # has shape (nTapers x nFreq x nChannels x nChannels)

--- a/syncopy/specest/mtmfft.py
+++ b/syncopy/specest/mtmfft.py
@@ -98,13 +98,13 @@ def mtmfft(data_arr,
 
     for taperIdx, win in enumerate(windows):
         win = np.tile(win, (nChannels, 1)).T
-        tapered = data_arr * win
+        win *= data_arr
         # de-mean again after tapering - needed for Granger!
         if demean_taper:
-            tapered = tapered - tapered.mean(axis=0)
+            win -= win.mean(axis=0)
         # real fft takes only 'half the energy'/positive frequencies,
         # multiply by 2 to correct for this
-        ftr[taperIdx] = 2 * np.fft.rfft(tapered, n=nSamples, axis=0)
+        ftr[taperIdx] = 2 * np.fft.rfft(win, n=nSamples, axis=0)
         # normalization
         ftr[taperIdx] /= np.sqrt(nSamples)
 

--- a/syncopy/specest/mtmfft.py
+++ b/syncopy/specest/mtmfft.py
@@ -8,7 +8,12 @@ import numpy as np
 from scipy import signal
 
 
-def mtmfft(data_arr, samplerate, nSamples=None, taper="hann", taper_opt=None):
+def mtmfft(data_arr,
+           samplerate,
+           nSamples=None,
+           taper="hann",
+           taper_opt=None,
+           demean_taper=False):
     """
     (Multi-)tapered fast Fourier transform. Returns
     full complex Fourier transform for each taper.
@@ -33,12 +38,8 @@ def mtmfft(data_arr, samplerate, nSamples=None, taper="hann", taper_opt=None):
         `'Kmax'` and `'NW'`.
         For further details, please refer to the
         `SciPy docs <https://docs.scipy.org/doc/scipy/reference/signal.windows.html>`_
-    n : int or None
-        Number of points along transformation axis in the input to use.
-        If `n` is smaller than the length of the input, the input is cropped.
-        If it is larger, the input is padded with zeros. If `n` is not given,
-        the length of the input along the axis specified by `axis` is used.
-
+    demean_taper : bool
+        Set to `True` to perform de-meaning after tapering
 
     Returns
     -------
@@ -97,9 +98,13 @@ def mtmfft(data_arr, samplerate, nSamples=None, taper="hann", taper_opt=None):
 
     for taperIdx, win in enumerate(windows):
         win = np.tile(win, (nChannels, 1)).T
+        tapered = data_arr * win
+        # de-mean again after tapering - needed for Granger!
+        if demean_taper:
+            tapered = tapered - tapered.mean(axis=0)
         # real fft takes only 'half the energy'/positive frequencies,
         # multiply by 2 to correct for this
-        ftr[taperIdx] = 2 * np.fft.rfft(data_arr * win, n=nSamples, axis=0)
+        ftr[taperIdx] = 2 * np.fft.rfft(tapered, n=nSamples, axis=0)
         # normalization
         ftr[taperIdx] /= np.sqrt(nSamples)
 

--- a/syncopy/tests/local_spy.py
+++ b/syncopy/tests/local_spy.py
@@ -20,52 +20,20 @@ import syncopy as spy
 from syncopy.tests.misc import generate_artificial_data
 from syncopy.tests import synth_data
 
-from pynwb import NWBHDF5IO
 
 
 # Prepare code to be executed using, e.g., iPython's `%run` magic command
 if __name__ == "__main__":
 
-    sys.exit()
+    mock_up = np.arange(24).reshape((8, 3))
+    ad1 = spy.AnalogData([mock_up] * 5)
 
-    nwbFilePath = "/home/fuertingers/Documents/job/SyNCoPy/Data/tt2.nwb"
-    # nwbFilePath = "/home/fuertingers/Documents/job/SyNCoPy/Data/test.nwb"
-
-    xx = spy.load_nwb(nwbFilePath)
-
-
-    # nwbio = NWBHDF5IO(nwbFilePath, "r", load_namespaces=True)
-    # nwbfile = nwbio.read()
-
-    # AR(2) Network test data
-    AdjMat = synth_data.mk_RandomAdjMat(nChannels)
-    trls = [100 * synth_data.AR2_network(AdjMat) for _ in range(nTrials)]
-    tdat1 = spy.AnalogData(trls, samplerate=fs)
-
-    # phase difusion test data
-    f1, f2 = 10, 40
+    nTrials = 50
+    nSamples = 200
     trls = []
     for _ in range(nTrials):
-
-        p1 = synth_data.phase_diffusion(f1, eps=.01, nChannels=nChannels, nSamples=nSamples)
-        p2 = synth_data.phase_diffusion(f2, eps=0.001, nChannels=nChannels, nSamples=nSamples)
-        trls.append(
-            1 * np.cos(p1) + 1 * np.cos(p2) + 0.6 * np.random.randn(
-                nSamples, nChannels))
-
-    tdat2 = spy.AnalogData(trls, samplerate=1000)
-
-
-    # Test stuff within here...
-    data1 = generate_artificial_data(nTrials=5, nChannels=16, equidistant=False, inmemory=False)
-    data2 = generate_artificial_data(nTrials=5, nChannels=16, equidistant=True, inmemory=False)
-
-
-
-    # client = spy.esi_cluster_setup(interactive=False)
-    # data1 + data2
-
-    # sys.exit()
-    # spec = spy.freqanalysis(artdata, method="mtmfft", taper="dpss", output="pow")
-
-
+        # defaults AR(2) parameters yield 40Hz peak
+        trls.append(synth_data.AR2_network(None, nSamples=nSamples))
+    ad1 = spy.AnalogData(trls, samplerate=200)
+    gr = spy.connectivityanalysis(ad1, method='granger', taper='dpss', tapsmofrq=3,
+                                  foilim=[0, 100])


### PR DESCRIPTION
…end checks

- Granger-Geweke needs full frequency range [0, Nyquist], this gets now
enforced in the connectivity fronted
- user gets warned if nChannels / nTrials is not small
- optional demeaning after tapering for mtmfft, only needed for
Granger so far, actually gives problems for coherence estimates at the 0-frequency
- resolves #194

On branch granger_improvements
Changes to be committed:
	modified:   syncopy/nwanalysis/ST_compRoutines.py
	modified:   syncopy/nwanalysis/connectivity_analysis.py
	modified:   syncopy/nwanalysis/csd.py
	modified:   syncopy/specest/mtmfft.py
	modified:   syncopy/tests/local_spy.py
	modified:   syncopy/tests/test_connectivity.py

Author Guidelines
-----------------
- [x] Is the change set **< 400 lines**?
These changes should not effect any of this
- [ ] ~Was the code checked for memory leaks/performance bottlenecks?~
- [ ] ~Is the code running locally **and** on the ESI cluster?~
- [ ] ~Is the code running on all supported platforms?~

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do **parallel** loops have a set length and correct termination conditions?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [ ] Code layout
  - [ ] Is the code PEP8 compliant?
  - [ ] Does the code adhere to agreed-upon naming conventions?
  - [ ] Are keywords clearly named and easy to understand?
  - [ ] No commented-out code?
- [ ] Are all docstrings complete and accurate?
