### PR TITLE
FIX: Always return lists when showing multiple trials

### DIFF
--- a/syncopy/datatype/methods/show.py
+++ b/syncopy/datatype/methods/show.py
@@ -129,31 +129,6 @@ def show(data, squeeze=True, **kwargs):
     for trlno in data.selection.trials:
         idxList.append(data._preview_trial(trlno).idx)
 
-    # Perform some slicing/list-selection gymnastics: ensure that selections
-    # that result in contiguous slices are actually returned as such (e.g.,
-    # `idxList = [(slice(1,2), [2]), (slice(2,3), [2])` -> `returnIdx = [slice(1,3), [2]]`)
-
-    # COMMENT: Do we really need this?
-    # We still want a list returned with one trial per list item, also for consecutive (or
-    # the default 'all') trials! toi selections without gap only happen in those cases..
-    # another mental burden of mixing time and trial indexing?!
-    # If not selecting consecutive trials, these gymnastics seem unnecessary as well?!
-
-    # FIXME: remove this part if vetted in review to be really unnecessary
-    # singleIdx = [False] * len(idxList[0])
-    # returnIdx = list(idxList[0])
-    # for sk, selectors in enumerate(zip(*idxList)):
-    #     print(selectors, np.unique(selectors), np.unique(selectors).size, len(selectors))
-    #     # toi and foi are lists/arrays and not slices like toilim/foilim
-    #     # so they get implicitly concatenated by np.unique
-    #     if np.unique(selectors).size == 1 or len(selectors) == 1:
-    #         singleIdx[sk] = True
-    #     else:
-    #         if all(isinstance(sel, slice) for sel in selectors):
-    #             gaps = [selectors[k + 1].start - selectors[k].stop for k in range(len(selectors) - 1)]
-    #             if all(gap == 0 for gap in gaps):
-    #                 singleIdx[sk] = True
-    #                 returnIdx[sk] = slice(selectors[0].start, selectors[-1].stop)
 
     # Reset in-place subset selection
     data.selection = None
@@ -164,11 +139,3 @@ def show(data, squeeze=True, **kwargs):
     # return multiple trials as list
     else:
         return [transform_out(data.data[idx]) for idx in idxList]
-
-    # FIXME: remove for the same reason as above
-    # If possible slice underlying dataset only once, otherwise return a list
-    # of arrays corresponding to selected trials
-    # if all(si == True for si in singleIdx):
-    #     return transform_out(data.data[tuple(returnIdx)])
-    # else:
-    #     return [transform_out(data.data[idx]) for idx in idxList]

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -413,8 +413,10 @@ class TestSelector():
             assert "no data selectors if `clear = True`" in str(spyval.value)
 
         # show full/squeezed arrays
-        assert len(ang.show(channel=0).shape) == 1
-        assert len(ang.show(channel=0, squeeze=False).shape) == 2
+        # for a single trial an array is returned directly
+        assert len(ang.show(channel=0, trials=0).shape) == 1
+        # multiple trials get returned in a list
+        assert [len(trl.shape) == 2 for trl in ang.show(channel=0, squeeze=False)]
 
         # go through all data-classes defined above
         for dclass in self.classes:

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -418,6 +418,13 @@ class TestSelector():
         # multiple trials get returned in a list
         assert [len(trl.shape) == 2 for trl in ang.show(channel=0, squeeze=False)]
 
+        # test toi/toilim returns arrays for single trial and
+        # lists for multiple trial selections
+        assert isinstance(ang.show(trials=0, toi=[0, 1]), np.ndarray)
+        assert isinstance(ang.show(trials=0, toilim=[0, 1]), np.ndarray)
+        assert isinstance(ang.show(trials=[0, 1], toi=[0, 1]), list)
+        assert isinstance(ang.show(trials=[0, 1], toilim=[0, 1]), list)
+        
         # go through all data-classes defined above
         for dclass in self.classes:
             dummy = getattr(spd, dclass)(data=self.data[dclass],


### PR DESCRIPTION
- closes #239 and #240
- the out of bounds behaviour of toi (not toilim) selections
is another pair of shoes entirely (downstream of `show`), and should get addressed elsewhere

On branch show-fixes
Changes to be committed:
	modified:   syncopy/datatype/methods/show.py
	modified:   syncopy/tests/test_selectdata.py

Author Guidelines
-----------------
- [x] Is the change set **< 400 lines**?
Only minor modifications shouldn't change anything below
- ~[ ] Was the code checked for memory leaks/performance bottlenecks?~
- ~[ ] Is the code running locally **and** on the ESI cluster?~
- ~[ ] Is the code running on all supported platforms?~

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do **parallel** loops have a set length and correct termination conditions?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [ ] Code layout
  - [ ] Is the code PEP8 compliant?
  - [ ] Does the code adhere to agreed-upon naming conventions?
  - [ ] Are keywords clearly named and easy to understand?
  - [ ] No commented-out code?
- [ ] Are all docstrings complete and accurate?
