### PR TITLE
FIX: trialtime property

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,5 +37,5 @@ keywords:
 - spectral-methods
 - brain
 repository-code: https://github.com/esi-neuroscience/syncopy
-version: 0.1b3.dev287
-date-released: '2022-01-19'
+version: 0.3.dev187
+date-released: '2022-04-13'

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -379,7 +379,7 @@ class BaseData(ABC):
             if self.__class__.__name__ == "SpikeData":
                 nCol = 3
             else: # EventData
-                nCol = 2
+                nCol = inData[0].shape[1]
             if any(val.shape[1] != nCol for val in inData):
                 lgl = "NumPy 2d-arrays with 3 columns"
                 act = "NumPy arrays of different shape"

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -1500,11 +1500,6 @@ class Selector():
         if self._dataClass == "CrossSpectralData":
             self._dimProps.remove("channel")
 
-        # DiscreteData cannot be selected by toi
-        if self._dataClass in ["EventData","SpikeData"]:
-            if select.get("toi") is not None:
-                raise(ValueError("toi cannot be used to select %s"%(self._dataClass)))
-
         # Assign defaults (trials are not a "real" property, handle it separately,
         # same goes for `trialdefinition`)
         self._trials = None

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -1500,6 +1500,11 @@ class Selector():
         if self._dataClass == "CrossSpectralData":
             self._dimProps.remove("channel")
 
+        # DiscreteData cannot be selected by toi
+        if self._dataClass in ["EventData","SpikeData"]:
+            if select.get("toi") is not None:
+                raise(ValueError("toi cannot be used to select %s"%(self._dataClass)))
+
         # Assign defaults (trials are not a "real" property, handle it separately,
         # same goes for `trialdefinition`)
         self._trials = None

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -608,6 +608,15 @@ class EventData(DiscreteData):
         :func:`syncopy.definetrial`
 
         """
+        if dimord is not None:
+            # ensure that event data can have extra dimord columns
+            if data.shape[1] != len(self._defaultDimord):
+                for col in self._defaultDimord:
+                    if col not in dimord:
+                        base = "dimensional label {}"
+                        lgl = base.format("'" + col + "'")
+                        raise SPYValueError(legal=lgl, varname="dimord")
+                self._defaultDimord = dimord
 
         # Call parent initializer
         super().__init__(data=data,

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -610,7 +610,7 @@ class EventData(DiscreteData):
         """
         if dimord is not None:
             # ensure that event data can have extra dimord columns
-            if data.shape[1] != len(self._defaultDimord):
+            if len(dimord) != len(self._defaultDimord):
                 for col in self._defaultDimord:
                     if col not in dimord:
                         base = "dimensional label {}"

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -182,9 +182,8 @@ class DiscreteData(BaseData, ABC):
     def trialtime(self):
         """list(:class:`numpy.ndarray`): trigger-relative sample times in s"""
         if self.samplerate is not None and self.sampleinfo is not None:
-            return [np.array([(t + self._t0[tk]) / self.samplerate \
-                              for t in range(0, int(self.sampleinfo[tk, 1] - self.sampleinfo[tk, 0]))]) \
-                    for tk in np.unique(self.trialid)]
+            return [(np.arange(0, stop - start) + self._t0[tk]) / self.samplerate \
+                    for tk, (start, stop) in enumerate(self.sampleinfo)]
 
     # Helper function that grabs a single trial
     def _get_trial(self, trialno):

--- a/syncopy/io/load_spy_container.py
+++ b/syncopy/io/load_spy_container.py
@@ -276,19 +276,17 @@ def _load(filename, checksum, mode, out):
                                 actual=hsh_msg.format(hsh=hsh))
 
     # Parsing is done, create new or check provided object
+    dimord = jsonDict.pop("dimord")
     if out is not None:
         try:
             data_parser(out, varname="out", writable=True, dataclass=jsonDict["dataclass"])
         except Exception as exc:
             raise exc
         new_out = False
+        out.dimord = dimord
     else:
-        out = dataclass()
+        out = dataclass(dimord=dimord)
         new_out = True
-
-    # First and foremost, assign dimensional information
-    dimord = jsonDict.pop("dimord")
-    out.dimord = dimord
 
     # Access data on disk (error checking is done by setters)
     out.mode = mode

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -171,10 +171,6 @@ class TestSpikeData():
             range(5, 8),  # narrow range
             slice(-5, None)  # negative-start slice
             ]
-        toiSelections = [
-            "all",  # non-type-conform string
-            [-0.2, 0.6, 0.9, 1.1, 1.3, 1.6, 1.8, 2.2, 2.45, 3.]  # unordered, inexact, repetions
-            ]
         toilimSelections = [
             [0.5, 3.5],  # regular range
             [1.0, np.inf]  # unbounded from above
@@ -185,8 +181,7 @@ class TestSpikeData():
             range(1, 4),  # narrow range
             slice(-2, None)  # negative-start slice
             ]
-        timeSelections = list(zip(["toi"] * len(toiSelections), toiSelections)) \
-            + list(zip(["toilim"] * len(toilimSelections), toilimSelections))
+        timeSelections = list(zip(["toilim"] * len(toilimSelections), toilimSelections))
 
         # Randomly pick one selection unless tests are run with `--full`
         if fulltests:
@@ -513,16 +508,11 @@ class TestEventData():
             range(0, 2),  # narrow range
             slice(-2, None)  # negative-start slice
             ]
-        toiSelections = [
-            "all",  # non-type-conform string
-            [-0.2, 0.6, 0.9, 1.1, 1.3, 1.6, 1.8, 2.2, 2.45, 3.]  # unordered, inexact, repetions
-            ]
         toilimSelections = [
             [0.5, 3.5],  # regular range
             [0.0, np.inf]  # unbounded from above
             ]
-        timeSelections = list(zip(["toi"] * len(toiSelections), toiSelections)) \
-            + list(zip(["toilim"] * len(toilimSelections), toilimSelections))
+        timeSelections = list(zip(["toilim"] * len(toilimSelections), toilimSelections))
 
         # Randomly pick one selection unless tests are run with `--full`
         if fulltests:

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -171,6 +171,10 @@ class TestSpikeData():
             range(5, 8),  # narrow range
             slice(-5, None)  # negative-start slice
             ]
+        toiSelections = [
+            "all",  # non-type-conform string
+            [-0.2, 0.6, 0.9, 1.1, 1.3, 1.6, 1.8, 2.2, 2.45, 3.]  # unordered, inexact, repetions
+            ]
         toilimSelections = [
             [0.5, 3.5],  # regular range
             [1.0, np.inf]  # unbounded from above
@@ -181,7 +185,8 @@ class TestSpikeData():
             range(1, 4),  # narrow range
             slice(-2, None)  # negative-start slice
             ]
-        timeSelections = list(zip(["toilim"] * len(toilimSelections), toilimSelections))
+        timeSelections = list(zip(["toi"] * len(toiSelections), toiSelections)) \
+            + list(zip(["toilim"] * len(toilimSelections), toilimSelections))
 
         # Randomly pick one selection unless tests are run with `--full`
         if fulltests:
@@ -508,11 +513,16 @@ class TestEventData():
             range(0, 2),  # narrow range
             slice(-2, None)  # negative-start slice
             ]
+        toiSelections = [
+            "all",  # non-type-conform string
+            [-0.2, 0.6, 0.9, 1.1, 1.3, 1.6, 1.8, 2.2, 2.45, 3.]  # unordered, inexact, repetions
+            ]
         toilimSelections = [
             [0.5, 3.5],  # regular range
             [0.0, np.inf]  # unbounded from above
             ]
-        timeSelections = list(zip(["toilim"] * len(toilimSelections), toilimSelections))
+        timeSelections = list(zip(["toi"] * len(toiSelections), toiSelections)) \
+            + list(zip(["toilim"] * len(toilimSelections), toilimSelections))
 
         # Randomly pick one selection unless tests are run with `--full`
         if fulltests:

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -670,6 +670,7 @@ class TestSelector():
             discrete = getattr(spd, dclass)(data=self.data[dclass],
                                             trialdefinition=self.trl[dclass],
                                             samplerate=self.samplerate)
+            discrIdx = [slice(None)] * len(discrete.dimord)
             for tselect in ["toi", "toilim"]:
                 for timeSel in selDict[tselect]:
                     sel = Selector(discrete, {tselect: timeSel}).time

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -333,6 +333,7 @@ class TestSelector():
     # Append customized columns to EventData dataset
     data["EventDataDimord"] = np.hstack([data["EventData"], data["EventData"]])
     trl["EventDataDimord"] = trl["AnalogData"]
+    customEvtDimord = ["sample", "eventid", "custom1", "custom2"]
 
     # Define data classes to be used in tests below
     classes = ["AnalogData", "SpectralData", "SpikeData", "EventData"]
@@ -345,7 +346,7 @@ class TestSelector():
         for dset in ["SpikeData", "EventData", "EventDataDimord"]:
             dclass = "".join(dset.partition("Data")[:2])
             prop = mapDict[dclass]
-            dimord = ["sample", "eventid", "custom1", "custom2"] if dset == "EventDataDimord" else None
+            dimord = self.customEvtDimord if dset == "EventDataDimord" else None
             discrete = getattr(spd, dclass)(data=self.data[dset],
                                             trialdefinition=self.trl[dclass],
                                             samplerate=self.samplerate,
@@ -436,7 +437,7 @@ class TestSelector():
         # go through all data-classes defined above
         for dset in self.data.keys():
             dclass = "".join(dset.partition("Data")[:2])
-            dimord = ["sample", "eventid", "custom1", "custom2"] if dset == "EventDataDimord" else None
+            dimord = self.customEvtDimord if dset == "EventDataDimord" else None
             dummy = getattr(spd, dclass)(data=self.data[dset],
                                          trialdefinition=self.trl[dclass],
                                          samplerate=self.samplerate,
@@ -679,12 +680,11 @@ class TestSelector():
         # the below method of extracting spikes satisfying `toi`/`toilim` only works w/equidistant trials!
         for dset in ["SpikeData", "EventData", "EventDataDimord"]:
             dclass = "".join(dset.partition("Data")[:2])
-            dimord = ["sample", "eventid", "custom1", "custom2"] if dset == "EventDataDimord" else None
-            discrete = getattr(spd, dclass)(data=self.data[dclass],
+            dimord = self.customEvtDimord if dset == "EventDataDimord" else None
+            discrete = getattr(spd, dclass)(data=self.data[dset],
                                             trialdefinition=self.trl[dclass],
                                             samplerate=self.samplerate,
                                             dimord=dimord)
-            discrIdx = [slice(None)] * len(discrete.dimord)
             for tselect in ["toi", "toilim"]:
                 for timeSel in selDict[tselect]:
                     sel = Selector(discrete, {tselect: timeSel}).time

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -665,27 +665,19 @@ class TestSelector():
                               [1.0, np.inf],  # unbounded from above
                               [-np.inf, 1.0])}  # unbounded from below
 
-        # all trials have same time-scale for both `EventData` and `SpikeData`: take 1st one as reference
-        # trlTime = (np.arange(0, self.trl["SpikeData"][0, 1] - self.trl["SpikeData"][0, 0])
-        #                 + self.trl["SpikeData"][0, 2]) / self.samplerate
-
         # the below method of extracting spikes satisfying `toi`/`toilim` only works w/equidistant trials!
         for dclass in ["SpikeData", "EventData"]:
             discrete = getattr(spd, dclass)(data=self.data[dclass],
                                             trialdefinition=self.trl[dclass],
                                             samplerate=self.samplerate)
-            discrIdx = [slice(None)] * len(discrete.dimord)
-            #timeIdx = discrete.dimord.index("time")
             for tselect in ["toi", "toilim"]:
                 for timeSel in selDict[tselect]:
-                    print({tselect: timeSel})
                     sel = Selector(discrete, {tselect: timeSel}).time
                     result = []
 
                     # compute sel by hand
                     for trlno in range(len(discrete.trials)):
                         trlTime = discrete.time[trlno]
-                        print('Test time', trlTime)
                         if timeSel is None or timeSel == "all":
                             idx = np.arange(trlTime.size).tolist()
                         else:
@@ -707,8 +699,6 @@ class TestSelector():
                                                     np.where(trlTime <= timeSel[1])[0]).tolist()
 
                         # check that correct data was selected
-                        print('Test idx', idx)
-                        print('My idx', sel[trlno])
                         assert np.array_equal(discrete.trials[trlno][idx, :],
                                             discrete.trials[trlno][sel[trlno], :])
                         if not isinstance(idx, slice) and len(idx) > 1:
@@ -723,57 +713,9 @@ class TestSelector():
                     # perform actual data-selection and ensure identity of results
                     selected = selectdata(discrete, {tselect: timeSel})
                     for trialno in range(len(discrete.trials)):
-                        #discrIdx[timeIdx] = result[trialno]
                         assert np.array_equal(selected.trials[trialno],
-                                            discrete.trials[trialno][result[trialno],:])#[tuple(discrIdx)])
-
-                # for timeSel in selDict[tselect]:
-                    # if isinstance(timeSel, list):
-                    #     smpIdx = []
-                    #     for tp in timeSel:
-                    #         if np.isfinite(tp):
-                    #             smpIdx.append(np.abs(np.array(trlTime) - tp).argmin())
-                    #         else:
-                    #             smpIdx.append(tp)
-                    # result = []
-                    # sel = Selector(discrete, {tselect: timeSel}).time
-                    # selected = selectdata(discrete, {tselect: timeSel})
-                    # tk = 0
-                    # for trlno in range(len(discrete.trials)):
-                    #     thisTrial = discrete.trials[trlno][:, 0]
-                    #     if isinstance(timeSel, list):
-                    #         if tselect == "toi":
-                    #             trlRes = []
-                    #             for idx in smpIdx:
-                    #                 trlRes += list(np.where(thisTrial == idx + trlno * self.lenTrial)[0])
-                    #         else:
-                    #             start = smpIdx[0] + trlno * self.lenTrial
-                    #             stop = smpIdx[1] + trlno * self.lenTrial
-                    #             candidates = np.intersect1d(thisTrial[thisTrial >= start],
-                    #                                         thisTrial[thisTrial <= stop])
-                    #             trlRes = []
-                    #             for cand in candidates:
-                    #                 trlRes += list(np.where(thisTrial == cand)[0])
-                    #     else:
-                    #         trlRes = slice(0, thisTrial.size, 1)
-
-                        # ensure that actually selected data is correct
-                        # assert np.array_equal(discrete.trials[trlno][trlRes, :],
-                        #                       discrete.trials[trlno][sel[trlno], :])
-                        # if sel[trlno]:
-                        #     assert np.array_equal(selected.trials[tk],
-                        #                           discrete.trials[trlno][sel[trlno], :])
-                        #     tk += 1
-
-                        # if not isinstance(trlRes, slice) and len(trlRes) > 1:
-                        #     sampSteps = np.diff(trlRes)
-                        #     if sampSteps.min() == sampSteps.max() == 1:
-                        #         trlRes = slice(trlRes[0], trlRes[-1] + 1, 1)
-                        # result.append(trlRes)
-
-                    # check correct format of selector (list -> slice etc.)
-                    # assert result == sel
-
+                                            discrete.trials[trialno][result[trialno],:])
+                        
     def test_spectral_foifoilim(self):
 
         # this selection only works w/the dummy frequency data constructed above!!!


### PR DESCRIPTION
Removed unique as that made the _get_time function incorrect. 
Code is now faster and identical to .time property in continuous_data.

Author Guidelines
-----------------
- [x] Is the change set **< 400 lines**?
- [ ] Was the code checked for memory leaks/performance bottlenecks?
- [ ] Is the code running locally **and** on the ESI cluster?
- [ ] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do **parallel** loops have a set length and correct termination conditions?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [ ] Code layout
  - [ ] Is the code PEP8 compliant?
  - [ ] Does the code adhere to agreed-upon naming conventions?
  - [ ] Are keywords clearly named and easy to understand?
  - [ ] No commented-out code?
- [ ] Are all docstrings complete and accurate?
