### PR TITLE
CHG: Capture explicit default settings if also in `cfg`

### DIFF
--- a/syncopy/shared/kwarg_decorators.py
+++ b/syncopy/shared/kwarg_decorators.py
@@ -94,6 +94,8 @@ def unwrap_cfg(func):
       being provided explicitly
     * ``func(data1, data2, kw1=val1, kw2=val2)``: same as above with multiple input
       objects
+    * ``func(data, cfg, kw2=val2)``: valid if `cfg` does NOT contain `'kw2'`
+
 
     Invalid call signatures:
 
@@ -104,6 +106,7 @@ def unwrap_cfg(func):
     * ``func(cfg, {})``: every dict in `func`'s positional argument list is interpreted
       as `cfg` "structure"
     * ``func(data, cfg=value)``: `cfg` must be a Python dict or :class:`~syncopy.StructDict`
+    * ``func(data, cfg, kw1=val1)``: invalid if keyword `'kw1'` also appears in `cfg`
 
     See also
     --------
@@ -169,14 +172,20 @@ def unwrap_cfg(func):
             # not manipulate `cfg` in user's namespace!
             cfg = StructDict(cfg) # FIXME
 
-            # If a method is called using `cfg`, non-default values for
-            # keyword arguments must *only* to be provided via `cfg`
-            defaults = get_defaults(func)
-            for key, value in kwargs.items():
-                if defaults.get(key, value) != value:
-                    raise SPYValueError(legal="no keyword arguments",
-                                        varname=key,
-                                        actual="non-default value for {}".format(key))
+            # If a meta-function is called using `cfg`, any (not only non-default) values for
+            # keyword arguments must *either* be provided via `cfg` or via standard kw
+            # NOTE: the frontend defaults not set by the user do NOT appear in `kwargs`!
+            for key in kwargs:
+                if key in cfg:
+                    lgl = f"parameter set either via `cfg.{key}=...` or as keyword"
+                    act = f"parameter `{key}` set in both `cfg` and via explicit keyword"
+                    raise SPYValueError(legal=lgl,
+                                        varname=f"cfg/{key}",
+                                        actual=act)
+                # now attach the explicit set keywords to `cfg`
+                # to be passed to the func call
+                else:
+                    cfg[key] = kwargs[key]
 
             # Translate any existing "yes" and "no" fields to `True` and `False`
             for key in cfg.keys():

--- a/syncopy/shared/kwarg_decorators.py
+++ b/syncopy/shared/kwarg_decorators.py
@@ -176,8 +176,11 @@ def unwrap_cfg(func):
             # keyword arguments must *either* be provided via `cfg` or via standard kw
             # NOTE: the frontend defaults not set by the user do NOT appear in `kwargs`!
             for key in kwargs:
-                if key in cfg:
-                    lgl = f"parameter set either via `cfg.{key}=...` or as keyword"
+                # these get special treatment below
+                if key in ['data', 'dataset']:
+                    continue
+                elif key in cfg:
+                    lgl = f"parameter set either via `cfg.{key}=...` or directly via keyword"
                     act = f"parameter `{key}` set in both `cfg` and via explicit keyword"
                     raise SPYValueError(legal=lgl,
                                         varname=f"cfg/{key}",

--- a/syncopy/specest/compRoutines.py
+++ b/syncopy/specest/compRoutines.py
@@ -185,7 +185,7 @@ class MultiTaperFFT(ComputationalRoutine):
     valid_kws = list(signature(mtmfft).parameters.keys())[1:]
     valid_kws += list(signature(mtmfft_cF).parameters.keys())[1:]
     # hardcode some parameter names which got digested from the frontend
-    valid_kws += ['tapsmofrq', 'nTaper']
+    valid_kws += ['tapsmofrq', 'nTaper', 'pad']
 
     def process_metadata(self, data, out):
 

--- a/syncopy/tests/test_decorators.py
+++ b/syncopy/tests/test_decorators.py
@@ -140,7 +140,7 @@ class TestSpyCalls():
         # keyword set via cfg and kwarg
         with pytest.raises(SPYValueError) as exc:
             group_objects(self.data, cfg, groupbychan="invalid")
-        assert "'non-default value for groupbychan'; expected no keyword arguments" in str(exc.value)
+        assert "set in both `cfg` and via explicit keyword" in str(exc.value)
 
         # both data and dataset in cfg/keywords
         cfg = StructDict()


### PR DESCRIPTION
- if the user sets a default value explicitly, e.i. `keeptrials=True`,
but `keeptrials` also appears in a provided `cfg` structure, raise a
`SPYValueError`
- both `cfg` and explicit keywords are allowed, as long as they are
mutually exclusive, e.i. `func(data, cfg={'pad' : 3},
keeptrials=False)` is valid
- minor fix: `'pad'` kw added to valid kws for MultiTaperFFT

On branch issue-278
Your branch is up to date with 'origin/dev'.

Changes to be committed:
	modified:   syncopy/shared/kwarg_decorators.py
	modified:   syncopy/specest/compRoutines.py

closes #278 

Author Guidelines
-----------------
- [x] Is the change set **< 400 lines**?
- [x] Was the code checked for memory leaks/performance bottlenecks?
- [x] Is the code running locally **and** on the ESI cluster?
- [x] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [x] Are testing routines present?
- [ ] Do **parallel** loops have a set length and correct termination conditions?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [x] Code layout
  - [x] Is the code PEP8 compliant?
  - [x] Does the code adhere to agreed-upon naming conventions?
  - [x] Are keywords clearly named and easy to understand?
  - [x] No commented-out code?
- [x] Are all docstrings complete and accurate?
