### PR TITLE
209 cfg

### DIFF
--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -1490,7 +1490,7 @@ class Selector():
 
         # Keep list of supported selectors in sync w/supported keywords of `selectdata`
         supported = list(signature(selectdata).parameters.keys())
-        for key in ["data", "out", "inplace", "clear", "parallel", "kwargs"]:
+        for key in ["data", "inplace", "clear", "parallel", "kwargs"]:
             supported.remove(key)
         # supported = ["trials", "channel", "channel_i", "channel_j", "toi",
         #              "toilim", "foi", "foilim", "taper", "unit", "eventid"]

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -124,9 +124,10 @@ class BaseData(ABC):
 
     @cfg.setter
     def cfg(self, dct):
+        """ For loading only, for processing the CR extends the existing (empty) cfg dictionary """
         if not isinstance(dct, dict):
             raise SPYTypeError(dct, varname="cfg", expected="dictionary-like object")
-        self._cfg = self._set_cfg(self._cfg, dct)
+        self._cfg = dct
 
     @property
     def container(self):
@@ -509,6 +510,7 @@ class BaseData(ABC):
 
     @log.setter
     def log(self, msg):
+        """ This appends the assigned msg to the existing log """
         if not isinstance(msg, str):
             raise SPYTypeError(msg, varname="log", expected="str")
         prefix = "\n\n|=== {user:s}@{host:s}: {time:s} ===|\n\n\t{caller:s}"
@@ -802,19 +804,6 @@ class BaseData(ABC):
     # Helper function converting object class-name to usable file extension
     def _classname_to_extension(self):
         return "." + self.__class__.__name__.split('Data')[0].lower()
-
-    # Helper function that digs into cfg dictionaries
-    def _set_cfg(self, cfg, dct):
-        dct = StructDict(dct)
-        if not cfg:
-            cfg = dct
-        else:
-            if "cfg" in cfg.keys():
-                self._set_cfg(cfg["cfg"], dct)
-            else:
-                cfg["cfg"] = dct
-                return cfg
-        return cfg
 
     # Legacy support
     def __repr__(self):

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -81,7 +81,6 @@ class BaseData(ABC):
     show = show
 
     # Initialize hidden attributes used by all children
-    _cfg = {}
     _filename = None
     _trialdefinition = None
     _dimord = None
@@ -948,7 +947,6 @@ class BaseData(ABC):
         # If we made it this far, `self` and `other` really seem to be identical
         return True
 
-
     # Class "constructor"
     def __init__(self, filename=None, dimord=None, mode="r+", **kwargs):
         """
@@ -958,6 +956,9 @@ class BaseData(ABC):
         2. data only
 
         """
+
+        # each instance needs its own cfg!
+        self._cfg = {}
 
         # Initialize hidden attributes
         for propertyName in self._hdfFileDatasetProperties:

--- a/syncopy/datatype/methods/show.py
+++ b/syncopy/datatype/methods/show.py
@@ -7,7 +7,7 @@
 import numpy as np
 
 # Local imports
-from syncopy.shared.errors import SPYInfo, SPYTypeError
+from syncopy.shared.errors import SPYInfo, SPYTypeError, SPYValueError
 
 __all__ = ["show"]
 

--- a/syncopy/datatype/methods/show.py
+++ b/syncopy/datatype/methods/show.py
@@ -8,12 +8,11 @@ import numpy as np
 
 # Local imports
 from syncopy.shared.errors import SPYInfo, SPYTypeError
-from syncopy.shared.kwarg_decorators import unwrap_cfg
+
 
 __all__ = ["show"]
 
 
-@unwrap_cfg
 def show(data, squeeze=True, **kwargs):
     """
     Show (partial) contents of Syncopy object

--- a/syncopy/io/load_spy_container.py
+++ b/syncopy/io/load_spy_container.py
@@ -304,8 +304,6 @@ def _load(filename, checksum, mode, out):
 
     # Write `cfg` entries
     thisMethod = sys._getframe().f_code.co_name.replace("_", "")
-    out.cfg = {"method": thisMethod,
-               "files": [hdfFile, jsonFile]}
 
     # Write log-entry
     msg = "Read files v. {ver:s} ".format(ver=jsonDict["_version"])

--- a/syncopy/io/load_spy_container.py
+++ b/syncopy/io/load_spy_container.py
@@ -302,7 +302,6 @@ def _load(filename, checksum, mode, out):
     for key in [prop for prop in dataclass._infoFileProperties if prop != "dimord"]:
         setattr(out, key, jsonDict[key])
 
-    # Write `cfg` entries
     thisMethod = sys._getframe().f_code.co_name.replace("_", "")
 
     # Write log-entry

--- a/syncopy/io/save_spy_container.py
+++ b/syncopy/io/save_spy_container.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# 
+#
 # Save Syncopy data objects to disk
-# 
+#
 
 # Builtin/3rd party package imports
 import os
@@ -26,71 +26,71 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
 
     The underlying array data object is stored in a HDF5 file, the metadata in
     a JSON file. Both can be placed inside a Syncopy container, which is a
-    regular directory with the extension '.spy'. 
+    regular directory with the extension '.spy'.
 
     Parameters
     ----------
     out : Syncopy data object
-        Object to be stored on disk.    
+        Object to be stored on disk.
     container : str
-        Path to Syncopy container folder (\*.spy) to be used for saving. If 
+        Path to Syncopy container folder (\*.spy) to be used for saving. If
         omitted, the extension '.spy' will be added to the folder name.
     tag : str
         Tag to be appended to container basename
     filename :  str
         Explicit path to data file. This is only necessary if the data should
         not be part of a container folder. An extension (\*.<dataclass>) is
-        added if omitted. The `tag` argument is ignored.      
+        added if omitted. The `tag` argument is ignored.
     overwrite : bool
-        If `True` an existing HDF5 file and its accompanying JSON file is 
-        overwritten (without prompt). 
-    memuse : scalar 
+        If `True` an existing HDF5 file and its accompanying JSON file is
+        overwritten (without prompt).
+    memuse : scalar
         Approximate in-memory cache size (in MB) for writing data to disk
         (only relevant for :class:`syncopy.VirtualData` or memory map data sources)
-        
+
     Returns
     -------
     Nothing : None
-    
+
     Notes
     ------
-    Syncopy objects may also be saved using the class method ``.save`` that 
-    acts as a wrapper for :func:`syncopy.save`, e.g., 
-    
+    Syncopy objects may also be saved using the class method ``.save`` that
+    acts as a wrapper for :func:`syncopy.save`, e.g.,
+
     >>> save(obj, container="new_spy_container")
-    
+
     is equivalent to
-    
+
     >>> obj.save(container="new_spy_container")
-    
+
     However, once a Syncopy object has been saved, the class method ``.save``
-    can be used as a shortcut to quick-save recent changes, e.g., 
-    
+    can be used as a shortcut to quick-save recent changes, e.g.,
+
     >>> obj.save()
-    
-    writes the current state of `obj` to the data/meta-data files on-disk 
-    associated with `obj` (overwriting both in the process). Similarly, 
-    
+
+    writes the current state of `obj` to the data/meta-data files on-disk
+    associated with `obj` (overwriting both in the process). Similarly,
+
     >>> obj.save(tag='newtag')
-    
-    saves `obj` in the current container 'new_spy_container' under a different 
-    tag. 
+
+    saves `obj` in the current container 'new_spy_container' under a different
+    tag.
 
     Examples
-    -------- 
+    --------
     Save the Syncopy data object `obj` on disk in the current working directory
     without creating a spy-container
-    
+
     >>> spy.save(obj, filename="session1")
     >>> # --> os.getcwd()/session1.<dataclass>
     >>> # --> os.getcwd()/session1.<dataclass>.info
-    
+
     Save `obj` without creating a spy-container using an absolute path
 
     >>> spy.save(obj, filename="/tmp/session1")
     >>> # --> /tmp/session1.<dataclass>
     >>> # --> /tmp/session1.<dataclass>.info
-    
+
     Save `obj` in a new spy-container created in the current working directory
 
     >>> spy.save(obj, container="container.spy")
@@ -104,7 +104,7 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
     >>> # --> /tmp/container.spy/container.<dataclass>.info
 
     Save `obj` in a new (or existing) spy-container under a different tag
-    
+
     >>> spy.save(obj, container="session1.spy", tag="someTag")
     >>> # --> os.getcwd()/session1.spy/session1_someTag.<dataclass>
     >>> # --> os.getcwd()/session1.spy/session1_someTag.<dataclass>.info
@@ -113,13 +113,13 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
     --------
     syncopy.load : load data created with :func:`syncopy.save`
     """
-    
+
     # Make sure `out` is a valid Syncopy data object
     data_parser(out, varname="out", writable=None, empty=False)
-    
+
     if filename is None and container is None:
         raise SPYError('filename and container cannot both be `None`')
-    
+
     if container is not None and filename is None:
         # construct filename from container name
         if not isinstance(container, str):
@@ -127,47 +127,47 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
         if not os.path.splitext(container)[1] == ".spy":
             container += ".spy"
         fileInfo = filename_parser(container)
-        filename = os.path.join(fileInfo["folder"], 
-                                fileInfo["container"], 
+        filename = os.path.join(fileInfo["folder"],
+                                fileInfo["container"],
                                 fileInfo["basename"])
-        # handle tag                
+        # handle tag
         if tag is not None:
             if not isinstance(tag, str):
                 raise SPYTypeError(tag, varname="tag", expected="str")
-            filename += '_' + tag            
+            filename += '_' + tag
 
     elif container is not None and filename is not None:
         raise SPYError("container and filename cannot be used at the same time")
-                              
+
     if not isinstance(filename, str):
         raise SPYTypeError(filename, varname="filename", expected="str")
-                                    
+
     # add extension if not part of the filename
     if "." not in os.path.splitext(filename)[1]:
         filename += out._classname_to_extension()
-    
+
     try:
         scalar_parser(memuse, varname="memuse", lims=[0, np.inf])
     except Exception as exc:
         raise exc
-    
+
     if not isinstance(overwrite, bool):
         raise SPYTypeError(overwrite, varname="overwrite", expected="bool")
-    
+
     # Parse filename for validity and construct full path to HDF5 file
     fileInfo = filename_parser(filename)
     if fileInfo["extension"] != out._classname_to_extension():
-        raise SPYError("""Extension in filename ({ext}) does not match data 
+        raise SPYError("""Extension in filename ({ext}) does not match data
                     class ({dclass})""".format(ext=fileInfo["extension"],
                                                 dclass=out.__class__.__name__))
     dataFile = os.path.join(fileInfo["folder"], fileInfo["filename"])
-    
+
     # If `out` is to replace its own on-disk representation, be more careful
     if overwrite and dataFile == out.filename:
         replace = True
     else:
         replace = False
-    
+
     # Prevent `out` from trying to re-create its own data file
     if replace:
         out.data.flush()
@@ -197,11 +197,11 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
                 else:
                     raise SPYIOError(dataFile, exists=True)
         h5f = h5py.File(dataFile, mode="w")
-        
+
         # Save each member of `_hdfFileDatasetProperties` in target HDF file
         for datasetName in out._hdfFileDatasetProperties:
             dataset = getattr(out, datasetName)
-            
+
             # Member is a memory map
             if isinstance(dataset, np.memmap):
                 # Given memory cap, compute how many data blocks can be grabbed
@@ -218,7 +218,7 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
                 for m, M in enumerate(n_blocks):
                     dat[m * nrow: m * nrow + M, :] = out.data[m * nrow: m * nrow + M, :]
                     out.clear()
-            
+
             # Member is a HDF5 dataset
             else:
                 dat = h5f.create_dataset(datasetName, data=dataset)
@@ -228,17 +228,13 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
     if replace:
         trl[()] = trl_arr
         trl.flush()
-    else:    
-        trl = h5f.create_dataset("trialdefinition", data=trl_arr, 
+    else:
+        trl = h5f.create_dataset("trialdefinition", data=trl_arr,
                                  maxshape=(None, trl_arr.shape[1]))
-    
+
     # Write to log already here so that the entry can be exported to json
     infoFile = dataFile + FILE_EXT["info"]
     out.log = "Wrote files " + dataFile + "\n\t\t\t" + 2*" " + infoFile
-    
-    # While we're at it, write cfg entries
-    out.cfg = {"method": sys._getframe().f_code.co_name,
-               "files": [dataFile, infoFile]}
 
     # Assemble dict for JSON output: order things by their "readability"
     outDict = OrderedDict(startInfoDict)
@@ -249,13 +245,13 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
     outDict["data_offset"] = dat.id.get_offset()
     outDict["trl_dtype"] = trl.dtype.name
     outDict["trl_shape"] = trl.shape
-    outDict["trl_offset"] = trl.id.get_offset()        
+    outDict["trl_offset"] = trl.id.get_offset()
     if isinstance(out.data, np.ndarray):
-        if np.isfortran(out.data): 
+        if np.isfortran(out.data):
             outDict["order"] = "F"
     else:
         outDict["order"] = "C"
-            
+
     for key in out._infoFileProperties:
         value = getattr(out, key)
         if isinstance(value, np.ndarray):
@@ -265,7 +261,7 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
             value = dict(value)
             _dict_converter(value)
         outDict[key] = value
-   
+
     # Save relevant stuff as HDF5 attributes
     for key in out._hdfFileAttributeProperties:
         if outDict[key] is None:
@@ -281,7 +277,7 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
                     filename.format(ext=FILE_EXT["info"])))
                 SPYWarning(msg.format(key, info_fle))
                 h5f.attrs[key] = [outDict[key][0], "...", outDict[key][-1]]
-    
+
     # Re-assign filename after saving (and remove source in case it came from `__storage__`)
     if not replace:
         h5f.close()
@@ -292,7 +288,7 @@ def save(out, container=None, tag=None, filename=None, overwrite=False, memuse=1
 
     # Compute checksum and finally write JSON (automatically overwrites existing)
     outDict["file_checksum"] = hash_file(dataFile)
-    
+
     with open(infoFile, 'w') as out_json:
         json.dump(outDict, out_json, indent=4)
 

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -345,6 +345,9 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
     av_compRoutine.pre_check()   # make sure we got a trial_average
     av_compRoutine.compute(st_out, out, parallel=False, log_dict=log_dict)
 
+    # attach potential older cfg's from the input
+    # to support chained frontend calls..
+    out.cfg.update(data.cfg)
     # attach frontend parameters for replay
     out.cfg.update({'connectivityanalysis': new_cfg})
     return out

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -8,7 +8,7 @@ import numpy as np
 
 # Syncopy imports
 from syncopy.shared.parsers import data_parser, scalar_parser
-from syncopy.shared.tools import get_defaults, best_match
+from syncopy.shared.tools import get_defaults, best_match, get_frontend_cfg
 from syncopy.datatype import CrossSpectralData
 from syncopy.shared.errors import (
     SPYValueError,
@@ -38,7 +38,7 @@ coh_outputs = {"abs", "pow", "complex", "fourier", "angle", "real", "imag"}
 def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                          foi=None, foilim=None, pad='maxperlen',
                          polyremoval=None, tapsmofrq=None, nTaper=None,
-                         taper="hann", taper_opt=None, out=None, **kwargs):
+                         taper="hann", taper_opt=None, **kwargs):
 
     """
     Perform connectivity analysis of Syncopy :class:`~syncopy.AnalogData` objects
@@ -152,8 +152,10 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
     lcls = locals()
     # check for ineffective additional kwargs
     check_passed_kwargs(lcls, defaults, frontend_name="connectivity")
-    # Ensure a valid computational method was selected
 
+    new_cfg = get_frontend_cfg(defaults, lcls, kwargs)
+
+    # Ensure a valid computational method was selected
     if method not in availableMethods:
         lgl = "'" + "or '".join(opt + "' " for opt in availableMethods)
         raise SPYValueError(legal=lgl, varname="method", actual=method)
@@ -324,39 +326,25 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
     # Perform the trial-parallelized computation of the matrix quantity
     st_compRoutine.initialize(data,
                               st_out._stackingDim,
-                              chan_per_worker=None, # no parallelisation over channels possible
-                              keeptrials=keeptrials) # we most likely need trial averaging!
+                              chan_per_worker=None,   # no parallelisation over channels possible
+                              keeptrials=keeptrials)  # we most likely need trial averaging!
     st_compRoutine.compute(data, st_out, parallel=kwargs.get("parallel"), log_dict=log_dict)
 
-    # if ever needed..
     # for single trial cross-corr results <-> keeptrials is True
-    if keeptrials and av_compRoutine is None:
-        if out is not None:
-            msg = "Single trial processing does not support `out` argument but directly returns the results"
-            SPYWarning(msg)
+    if av_compRoutine is None:
         return st_out
 
     # ----------------------------------------------------------------------------------
     # Sanitize output and call the chosen ComputationalRoutine on the averaged ST output
     # ----------------------------------------------------------------------------------
 
-    # If provided, make sure output object is appropriate
-    if out is not None:
-        try:
-            data_parser(out, varname="out", writable=True, empty=True,
-                        dataclass="CrossSpectralData",
-                        dimord=st_dimord)
-        except Exception as exc:
-            raise exc
-        new_out = False
-    else:
-        out = CrossSpectralData(dimord=st_dimord)
-        new_out = True
+    out = CrossSpectralData(dimord=st_dimord)
 
     # now take the trial average from the single trial CR as input
     av_compRoutine.initialize(st_out, out._stackingDim, chan_per_worker=None)
-    av_compRoutine.pre_check() # make sure we got a trial_average
+    av_compRoutine.pre_check()   # make sure we got a trial_average
     av_compRoutine.compute(st_out, out, parallel=False, log_dict=log_dict)
 
-    # Either return newly created output object or simply quit
-    return out if new_out else None
+    # attach frontend parameters for replay
+    out.cfg.update({'connectivityanalysis': new_cfg})
+    return out

--- a/syncopy/preproc/preprocessing.py
+++ b/syncopy/preproc/preprocessing.py
@@ -304,6 +304,7 @@ def preprocessing(
             filtered, rectified, parallel=kwargs.get("parallel"), log_dict=log_dict
         )
         del filtered
+        rectified.cfg.update(data.cfg)
         rectified.cfg.update({'preprocessing': new_cfg})
         return rectified
 
@@ -321,10 +322,14 @@ def preprocessing(
             filtered, htrafo, parallel=kwargs.get("parallel"), log_dict=log_dict
         )
         del filtered
+        htrafo.cfg.update(data.cfg)
         htrafo.cfg.update({'preprocessing': new_cfg})
         return htrafo
 
     # no post-processing
     else:
+        # attach potential older cfg's from the input
+        # to support chained frontend calls..
+        filtered.cfg.update(data.cfg)
         filtered.cfg.update({'preprocessing': new_cfg})
         return filtered

--- a/syncopy/preproc/preprocessing.py
+++ b/syncopy/preproc/preprocessing.py
@@ -9,7 +9,7 @@ import numpy as np
 # Syncopy imports
 from syncopy import AnalogData
 from syncopy.shared.parsers import data_parser, scalar_parser, array_parser
-from syncopy.shared.tools import get_defaults
+from syncopy.shared.tools import get_defaults, get_frontend_cfg
 from syncopy.shared.errors import SPYValueError, SPYInfo
 from syncopy.shared.kwarg_decorators import (
     unwrap_cfg,
@@ -107,6 +107,8 @@ def preprocessing(
     lcls = locals()
     # check for ineffective additional kwargs
     check_passed_kwargs(lcls, defaults, frontend_name="preprocessing")
+
+    new_cfg = get_frontend_cfg(defaults, lcls, kwargs)
 
     if filter_class not in availableFilters:
         lgl = "'" + "or '".join(opt + "' " for opt in availableFilters)
@@ -302,6 +304,7 @@ def preprocessing(
             filtered, rectified, parallel=kwargs.get("parallel"), log_dict=log_dict
         )
         del filtered
+        rectified.cfg.update({'preprocessing': new_cfg})
         return rectified
 
     elif hilbert:
@@ -318,8 +321,10 @@ def preprocessing(
             filtered, htrafo, parallel=kwargs.get("parallel"), log_dict=log_dict
         )
         del filtered
+        htrafo.cfg.update({'preprocessing': new_cfg})
         return htrafo
 
     # no post-processing
     else:
+        filtered.cfg.update({'preprocessing': new_cfg})
         return filtered

--- a/syncopy/preproc/resampledata.py
+++ b/syncopy/preproc/resampledata.py
@@ -9,7 +9,7 @@ import numpy as np
 # Syncopy imports
 from syncopy import AnalogData
 from syncopy.shared.parsers import data_parser, scalar_parser
-from syncopy.shared.tools import get_defaults
+from syncopy.shared.tools import get_defaults, get_frontend_cfg
 from syncopy.shared.errors import SPYValueError, SPYWarning, SPYInfo
 from syncopy.shared.kwarg_decorators import (
     unwrap_cfg,
@@ -106,6 +106,8 @@ def resampledata(data,
     lcls = locals()
     # check for ineffective additional kwargs
     check_passed_kwargs(lcls, defaults, frontend_name="resampledata")
+
+    new_cfg = get_frontend_cfg(defaults, lcls, kwargs)
 
     # check resampling frequency
     scalar_parser(resamplefs, varname="resamplefs", lims=[1, np.inf])
@@ -220,5 +222,5 @@ def resampledata(data,
     resampleMethod.compute(
         data, resampled, parallel=kwargs.get("parallel"), log_dict=log_dict
     )
-
+    resampled.cfg.update({'resampledata': new_cfg})
     return resampled

--- a/syncopy/preproc/resampledata.py
+++ b/syncopy/preproc/resampledata.py
@@ -222,5 +222,7 @@ def resampledata(data,
     resampleMethod.compute(
         data, resampled, parallel=kwargs.get("parallel"), log_dict=log_dict
     )
+
+    resampled.cfg.update(data.cfg)
     resampled.cfg.update({'resampledata': new_cfg})
     return resampled

--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -998,10 +998,6 @@ class ComputationalRoutine(ABC):
                                                         value=str(v) if len(str(v)) < 80
                                                         else str(v)[:30] + ", ..., " + str(v)[-30:])
         out.log = logHead + logOpts
-        # attach CR cfg to output data object
-        # in case of chained CRs, keep old cfg
-        new_cfg = {self.__class__.__name__: cfg}
-        out.cfg.update(new_cfg)
 
     @abstractmethod
     def process_metadata(self, data, out):

--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -22,7 +22,7 @@ if sys.platform == "win32":
 
 # Local imports
 from .tools import get_defaults
-from syncopy import __storage__, __acme__, __path__
+from syncopy import __storage__, __acme__
 from syncopy.shared.errors import SPYValueError, SPYTypeError, SPYParallelError, SPYWarning
 if __acme__:
     from acme import ParallelMap
@@ -285,8 +285,9 @@ class ComputationalRoutine(ABC):
         trials = []
         for tk, trialno in enumerate(self.trialList):
             trial = data._preview_trial(trialno)
-            trlArg = tuple(arg[tk] if isinstance(arg, (list, tuple, np.ndarray)) and len(arg) == self.numTrials \
-                else arg for arg in self.argv)
+            trlArg = tuple(arg[tk] if isinstance(arg, (list, tuple, np.ndarray)) and
+                           len(arg) == self.numTrials
+                           else arg for arg in self.argv)
             chunkShape, dtype = self.computeFunction(trial,
                                                      *trlArg,
                                                      **dryRunKwargs)
@@ -337,8 +338,9 @@ class ComputationalRoutine(ABC):
 
         # Allocate control variables
         trial = trials[0]
-        trlArg0 = tuple(arg[0] if isinstance(arg, (list, tuple, np.ndarray)) and len(arg) == self.numTrials \
-            else arg for arg in self.argv)
+        trlArg0 = tuple(arg[0] if isinstance(arg, (list, tuple, np.ndarray)) and
+                        len(arg) == self.numTrials
+                        else arg for arg in self.argv)
         chunkShape0 = tuple(chk_arr[0, :])
         lyt = [slice(0, stop) for stop in chunkShape0]
         sourceLayout = []
@@ -354,7 +356,7 @@ class ComputationalRoutine(ABC):
             # Set up channel-chunking: `c_blocks` holds channel blocks per trial
             nChannels = data.channel.size
             rem = int(nChannels % chan_per_worker)
-            c_blocks = [chan_per_worker] * int(nChannels//chan_per_worker) + [rem] * int(rem > 0)
+            c_blocks = [chan_per_worker] * int(nChannels // chan_per_worker) + [rem] * int(rem > 0)
             inchanidx = data.dimord.index("channel")
 
             # Perform dry-run w/first channel-block of first trial to identify
@@ -403,8 +405,9 @@ class ComputationalRoutine(ABC):
         stacking = targetLayout[0][stackingDim].stop
         for tk in range(1, self.numTrials):
             trial = trials[tk]
-            trlArg = tuple(arg[tk] if isinstance(arg, (list, tuple, np.ndarray)) and len(arg) == self.numTrials \
-                else arg for arg in self.argv)
+            trlArg = tuple(arg[tk] if isinstance(arg, (list, tuple, np.ndarray)) and
+                           len(arg) == self.numTrials
+                           else arg for arg in self.argv)
             chkshp = chk_list[tk]
             lyt = [slice(0, stop) for stop in chkshp]
             lyt[stackingDim] = slice(stacking, stacking + chkshp[stackingDim])
@@ -424,7 +427,7 @@ class ComputationalRoutine(ABC):
                     idx[inchanidx] = slice(blockstack, blockstack + block)
                     trial.shape = tuple(shp)
                     trial.idx = tuple(idx)
-                    res, _ = self.computeFunction(trial, *trlArg, **dryRunKwargs) # FauxTrial
+                    res, _ = self.computeFunction(trial, *trlArg, **dryRunKwargs)   # FauxTrial
                     lyt[outchanidx] = slice(chanstack, chanstack + res[outchanidx])
                     targetLayout.append(tuple(lyt))
                     targetShapes.append(tuple([slc.stop - slc.start for slc in lyt]))
@@ -462,7 +465,7 @@ class ComputationalRoutine(ABC):
                         sel = [sel]
                     if isinstance(sel, list):
                         selarr = np.array(sel, dtype=np.intp)
-                    else: # sel is a slice
+                    else:   # sel is a slice
                         step = sel.step
                         if sel.step is None:
                             step = 1
@@ -886,9 +889,10 @@ class ComputationalRoutine(ABC):
                 ingrid = self.sourceLayout[nblock]
                 sigrid = self.sourceSelectors[nblock]
                 outgrid = self.targetLayout[nblock]
-                argv = tuple(arg[nblock] \
-                    if isinstance(arg, (list, tuple, np.ndarray)) and len(arg) == self.numTrials \
-                        else arg for arg in self.argv)
+                argv = tuple(arg[nblock]
+                             if isinstance(arg, (list, tuple, np.ndarray)) and
+                             len(arg) == self.numTrials
+                             else arg for arg in self.argv)
 
                 # Catch empty source-array selections; this workaround is not
                 # necessary for h5py version 2.10+ (see https://github.com/h5py/h5py/pull/1174)
@@ -994,7 +998,10 @@ class ComputationalRoutine(ABC):
                                                         value=str(v) if len(str(v)) < 80
                                                         else str(v)[:30] + ", ..., " + str(v)[-30:])
         out.log = logHead + logOpts
-        out.cfg = cfg
+        # attach CR cfg to output data object
+        # in case of chained CRs, keep old cfg
+        new_cfg = {self.__class__.__name__: cfg}
+        out.cfg.update(new_cfg)
 
     @abstractmethod
     def process_metadata(self, data, out):

--- a/syncopy/shared/kwarg_decorators.py
+++ b/syncopy/shared/kwarg_decorators.py
@@ -10,9 +10,9 @@ import inspect
 import numpy as np
 
 # Local imports
-from syncopy.shared.errors import (SPYIOError, SPYTypeError, SPYValueError,
+from syncopy.shared.errors import (SPYTypeError, SPYValueError,
                                    SPYError, SPYWarning)
-from syncopy.shared.tools import StructDict, get_defaults
+from syncopy.shared.tools import StructDict
 import syncopy as spy
 if spy.__acme__:
     import dask.distributed as dd
@@ -168,9 +168,13 @@ def unwrap_cfg(func):
             if not isinstance(cfg, dict):
                 raise SPYTypeError(cfg, varname="cfg", expected="dictionary-like")
 
+            # check if we have saved pre-sets (replay a frontend run via out.cfg)
+            if func.__name__ in cfg.keys():
+                cfg = StructDict(cfg[func.__name__])
+
             # IMPORTANT: create a copy of `cfg` using `StructDict` constructor to
             # not manipulate `cfg` in user's namespace!
-            cfg = StructDict(cfg) # FIXME
+            cfg = StructDict(cfg)
 
             # If a meta-function is called using `cfg`, any (not only non-default) values for
             # keyword arguments must *either* be provided via `cfg` or via standard kw

--- a/syncopy/shared/tools.py
+++ b/syncopy/shared/tools.py
@@ -47,6 +47,45 @@ class StructDict(dict):
         return ppStr
 
 
+def get_frontend_cfg(defaults, lcls, kwargs):
+
+    """
+    Assemble cfg dict to allow direct replay of frontend calls
+
+    Parameters
+    ----------
+
+    defaults : dict
+        The result of :func:`~get_defaults`, holding all frontend specific
+        parameter names and default values
+    lcls : dict
+        The `locals()` within a frontend call, contains passed
+        parameter names and values
+    kwargs : dict
+        The `kwargs` attached to every frontend signature, holding
+        additional arguments, e.g. `parallel` and `select`
+
+    Returns
+    -------
+    new_cfg : :class:`~StructDict`
+        Holds all (default and non-default) parameter key-value
+        pairs passed to the frontend
+
+    """
+
+    # create new cfg dict
+    new_cfg = StructDict()
+    for par_name in defaults:
+        # check only needed for injected kwargs like `parallel`
+        if par_name in lcls:
+            new_cfg[par_name] = lcls[par_name]
+    # attach additional kwargs (like select)
+    for key in kwargs:
+        new_cfg[key] = kwargs[key]
+
+    return new_cfg
+
+
 def best_match(source, selection, span=False, tol=None, squash_duplicates=False):
     """
     Find matching elements in a given 1d-array/list
@@ -199,5 +238,3 @@ def get_defaults(obj):
     dct = {k: v.default for k, v in inspect.signature(obj).parameters.items()\
            if v.default != v.empty and v.name != "cfg"}
     return StructDict(dct)
-
-

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -842,6 +842,10 @@ def freqanalysis(data, method='mtmfft', output='pow',
                              keeptrials=keeptrials)
     specestMethod.compute(data, out, parallel=kwargs.get("parallel"), log_dict=log_dct)
 
+    # attach potential older cfg's from the input
+    # to support chained frontend calls..
+    out.cfg.update(data.cfg)
+
     # attach frontend parameters for replay
     out.cfg.update({'freqanalysis': new_cfg})
     return out

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -8,7 +8,7 @@ import numpy as np
 
 # Syncopy imports
 from syncopy.shared.parsers import data_parser, scalar_parser, array_parser
-from syncopy.shared.tools import get_defaults, StructDict, get_frontend_cfg
+from syncopy.shared.tools import get_defaults, get_frontend_cfg
 from syncopy.datatype import SpectralData
 from syncopy.shared.errors import SPYValueError, SPYTypeError, SPYWarning, SPYInfo
 from syncopy.shared.kwarg_decorators import (unwrap_cfg, unwrap_select,

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -8,7 +8,7 @@ import numpy as np
 
 # Syncopy imports
 from syncopy.shared.parsers import data_parser, scalar_parser, array_parser
-from syncopy.shared.tools import get_defaults
+from syncopy.shared.tools import get_defaults, StructDict
 from syncopy.datatype import SpectralData
 from syncopy.shared.errors import SPYValueError, SPYTypeError, SPYWarning, SPYInfo
 from syncopy.shared.kwarg_decorators import (unwrap_cfg, unwrap_select,
@@ -852,6 +852,14 @@ def freqanalysis(data, method='mtmfft', output='pow',
                              chan_per_worker=kwargs.get("chan_per_worker"),
                              keeptrials=keeptrials)
     specestMethod.compute(data, out, parallel=kwargs.get("parallel"), log_dict=log_dct)
+
+    # create new cfg dict
+    new_cfg = StructDict()
+    for setting in defaults:
+        # only for injected kwargs like `parallel`
+        if setting in lcls:
+            new_cfg[setting] = lcls[setting]
+    out.cfg.update({'freqanalysis': new_cfg})
 
     # Either return newly created output object or simply quit
     return out if new_out else None

--- a/syncopy/tests/local_spy.py
+++ b/syncopy/tests/local_spy.py
@@ -39,5 +39,6 @@ if __name__ == "__main__":
                                    nSamples=nSamples,
                                    alphas=alphas)
 
-    spec = spy.freqanalysis(adata, tapsmofrq=2, keeptrials=False)
     foi = np.linspace(40, 160, 25)
+    spec = spy.freqanalysis(adata, tapsmofrq=2, keeptrials=False, foi=foi)
+

--- a/syncopy/tests/test_cfg.py
+++ b/syncopy/tests/test_cfg.py
@@ -48,11 +48,11 @@ class TestCfg:
 
         for frontend in availableFrontend_cfgs.keys():
 
-            res = getattr(spy, frontend)(self.adata, cfg=availableFrontend_cfgs[frontend])
+            # unwrap cfg into keywords
+            res = getattr(spy, frontend)(self.adata, **availableFrontend_cfgs[frontend])
             # now replay with cfg from preceding frontend call
             res2 = getattr(spy, frontend)(self.adata, res.cfg)
 
-            print(frontend)
             # same results
             assert np.allclose(res.data[:], res2.data[:])
             assert res.cfg == res2.cfg

--- a/syncopy/tests/test_cfg.py
+++ b/syncopy/tests/test_cfg.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+#
+# Test cfg structure to replay frontend calls
+#
+
+import pytest
+import numpy as np
+import inspect
+
+# Local imports
+import syncopy as spy
+from syncopy import __acme__
+if __acme__:
+    import dask.distributed as dd
+
+import syncopy.tests.synth_data as synth_data
+
+# Decorator to decide whether or not to run dask-related tests
+skip_without_acme = pytest.mark.skipif(not __acme__, reason="acme not available")
+
+availableFrontend_cfgs = {'freqanalysis': {'method': 'mtmconvol', 't_ftimwin': 0.1},
+                          'preprocessing': {'freq': 10, 'filter_class': 'firws', 'filter_type': 'hp'},
+                          'resampledata': {'resamplefs': 125, 'lpfreq': 100},
+                          'connectivityanalysis': {'method': 'coh', 'tapsmofrq': 5}
+                          }
+
+
+class TestCfg:
+
+    nSamples = 100
+    nChannels = 3
+    nTrials = 10
+    fs = 200
+    fNy = fs / 2
+
+    # -- use flat white noise as test data --
+
+    adata = synth_data.white_noise(nTrials,
+                                   nSamples=nSamples,
+                                   nChannels=nChannels,
+                                   samplerate=fs)
+
+    # for toi tests, -1s offset
+    time_span = [-.9, -.6]
+    flow, fhigh = 0.3 * fNy, 0.4 * fNy
+
+    def test_single_frontends(self):
+
+        for frontend in availableFrontend_cfgs.keys():
+
+            res = getattr(spy, frontend)(self.adata, cfg=availableFrontend_cfgs[frontend])
+            # now replay with cfg from preceding frontend call
+            res2 = getattr(spy, frontend)(self.adata, res.cfg)
+
+            print(frontend)
+            # same results
+            assert np.all(res.data[:] == res2.data[:])
+            assert res.cfg == res2.cfg
+
+            # check that it's not just the defaults
+            if frontend == 'freqanalysis':
+                res3 = getattr(spy, frontend)(self.adata)
+                assert np.any(res.data[:] != res3.data[:])
+                assert res.cfg != res3.cfg
+
+    def test_selection(self):
+
+        select = {'toilim': self.time_span, 'trials': [1, 2, 3], 'channel': [2, 0]}
+        for frontend in availableFrontend_cfgs.keys():
+            res = getattr(spy, frontend)(self.adata,
+                                         cfg=availableFrontend_cfgs[frontend],
+                                         select=select)
+
+            # now replay with cfg from preceding frontend call
+            res2 = getattr(spy, frontend)(self.adata, res.cfg)
+
+            # same results
+            assert 'select' in res.cfg[frontend]
+            assert 'select' in res2.cfg[frontend]
+            assert np.all(res.data[:] == res2.data[:])
+            assert res.cfg == res2.cfg
+
+    def test_chaining_frontends(self):
+
+        # only preprocessing makes sense to chain atm
+        res_pp = spy.preprocessing(self.adata, cfg=availableFrontend_cfgs['preprocessing'])
+
+        for frontend in availableFrontend_cfgs.keys():
+            res = getattr(spy, frontend)(res_pp,
+                                         cfg=availableFrontend_cfgs[frontend])
+
+            # now replay with cfg from preceding frontend calls
+            # note we can use the final results `res.cfg` for both calls!
+            res_pp2 = spy.preprocessing(self.adata, res.cfg)
+            res2 = getattr(spy, frontend)(res_pp2, res.cfg)
+
+            # same results
+            assert np.all(res.data[:] == res2.data[:])
+            assert res.cfg == res2.cfg
+
+    @skip_without_acme
+    def test_parallel(self, testcluster=None):
+
+        client = dd.Client(testcluster)
+        all_tests = [attr for attr in self.__dir__()
+                     if (inspect.ismethod(getattr(self, attr)) and 'parallel' not in attr)]
+
+        for test_name in all_tests:
+            test_method = getattr(self, test_name)
+            test_method()
+        client.close()
+
+
+if __name__ == '__main__':
+    T1 = TestCfg()

--- a/syncopy/tests/test_cfg.py
+++ b/syncopy/tests/test_cfg.py
@@ -54,7 +54,7 @@ class TestCfg:
 
             print(frontend)
             # same results
-            assert np.all(res.data[:] == res2.data[:])
+            assert np.allclose(res.data[:], res2.data[:])
             assert res.cfg == res2.cfg
 
             # check that it's not just the defaults
@@ -77,7 +77,7 @@ class TestCfg:
             # same results
             assert 'select' in res.cfg[frontend]
             assert 'select' in res2.cfg[frontend]
-            assert np.all(res.data[:] == res2.data[:])
+            assert np.allclose(res.data[:], res2.data[:])
             assert res.cfg == res2.cfg
 
     def test_chaining_frontends(self):
@@ -95,7 +95,7 @@ class TestCfg:
             res2 = getattr(spy, frontend)(res_pp2, res.cfg)
 
             # same results
-            assert np.all(res.data[:] == res2.data[:])
+            assert np.allclose(res.data[:], res2.data[:])
             assert res.cfg == res2.cfg
 
     @skip_without_acme

--- a/syncopy/tests/test_cfg.py
+++ b/syncopy/tests/test_cfg.py
@@ -25,7 +25,8 @@ skip_without_acme = pytest.mark.skipif(not __acme__, reason="acme not available"
 availableFrontend_cfgs = {'freqanalysis': {'method': 'mtmconvol', 't_ftimwin': 0.1},
                           'preprocessing': {'freq': 10, 'filter_class': 'firws', 'filter_type': 'hp'},
                           'resampledata': {'resamplefs': 125, 'lpfreq': 100},
-                          'connectivityanalysis': {'method': 'coh', 'tapsmofrq': 5}
+                          'connectivityanalysis': {'method': 'coh', 'tapsmofrq': 5},
+                          'selectdata': {'trials': [1, 7, 3], 'channel': [2, 0]}
                           }
 
 
@@ -94,6 +95,9 @@ class TestCfg:
 
         select = {'toilim': self.time_span, 'trials': [1, 2, 3], 'channel': [2, 0]}
         for frontend in availableFrontend_cfgs.keys():
+            # select kw for selectdata makes no direct sense
+            if frontend == 'selectdata':
+                continue
             res = getattr(spy, frontend)(self.adata,
                                          cfg=availableFrontend_cfgs[frontend],
                                          select=select)

--- a/syncopy/tests/test_computationalroutine.py
+++ b/syncopy/tests/test_computationalroutine.py
@@ -235,9 +235,11 @@ class TestComputationalRoutine():
             out = filter_manager(self.sigdata, self.b, self.a, select=select,
                                  log_dict={"a": "this is a", "b": "this is b"})
 
+            # access the cfg belonging to the (single) CR
+            cr_cfg = out.cfg['LowPassFilter']
             # only keyword args (`a` in this case here) are stored in `cfg`
-            assert set(["a"]) == set(out.cfg.keys())
-            assert np.array_equal(out.cfg["a"], self.a)
+            assert set(["a"]) == set(cr_cfg.keys())
+            assert np.array_equal(cr_cfg["a"], self.a)
             assert len(out.trials) == len(sel.trials)
             # ensure our `log_dict` specification was respected
             assert "lowpass" in out._log
@@ -251,8 +253,8 @@ class TestComputationalRoutine():
                 selected = self.sigdata.selectdata(**select)
             out_sel = filter_manager(selected, self.b, self.a,
                                      log_dict={"a": "this is a", "b": "this is b"})
-            assert set(["a"]) == set(out.cfg.keys())
-            assert np.array_equal(out.cfg["a"], self.a)
+            assert set(["a"]) == set(cr_cfg.keys())
+            assert np.array_equal(cr_cfg["a"], self.a)
             assert len(out.trials) == len(out_sel.trials)
             assert "lowpass" in out._log
             assert "a = this is a" in out._log
@@ -263,8 +265,8 @@ class TestComputationalRoutine():
                 fname = os.path.join(tdir, "dummy")
                 out.save(fname)
                 dummy = load(fname)
-                assert "a" in dummy.cfg.keys()
-                assert np.array_equal(dummy.cfg["a"], self.a)
+                assert "a" in dummy.cfg['LowPassFilter'].keys()
+                assert np.array_equal(dummy.cfg['LowPassFilter']["a"], self.a)
                 assert out.filename == dummy.filename
                 if select is None:
                     reference = self.orig
@@ -283,8 +285,8 @@ class TestComputationalRoutine():
                 fname2 = os.path.join(tdir, "dummy2")
                 out_sel.save(fname2)
                 dummy2 = load(fname2)
-                assert "a" in dummy2.cfg.keys()
-                assert np.array_equal(dummy2.cfg["a"], dummy.cfg["a"])
+                assert "a" in dummy2.cfg['LowPassFilter'].keys()
+                assert np.array_equal(dummy2.cfg['LowPassFilter']["a"], dummy.cfg['LowPassFilter']["a"])
                 assert np.array_equal(dummy.data, dummy2.data)
                 assert np.array_equal(dummy.channel, dummy2.channel)
                 assert np.array_equal(dummy.time, dummy2.time)
@@ -439,10 +441,11 @@ class TestComputationalRoutine():
                 out = filter_manager(self.sigdata, self.b, self.a, select=select,
                                      log_dict={"a": "this is a", "b": "this is b"},
                                      parallel=True, parallel_store=parallel_store)
-
+                
+                cr_cfg = out.cfg['LowPassFilter']
                 # only keyword args (`a` in this case here) are stored in `cfg`
-                assert set(["a"]) == set(out.cfg.keys())
-                assert np.array_equal(out.cfg["a"], self.a)
+                assert set(["a"]) == set(cr_cfg.keys())
+                assert np.array_equal(cr_cfg["a"], self.a)
                 assert len(out.trials) == len(sel.trials)
                 # ensure our `log_dict` specification was respected
                 assert "lowpass" in out._log
@@ -458,8 +461,8 @@ class TestComputationalRoutine():
                                          log_dict={"a": "this is a", "b": "this is b"},
                                          parallel=True, parallel_store=parallel_store)
                 # only keyword args (`a` in this case here) are stored in `cfg`
-                assert set(["a"]) == set(out.cfg.keys())
-                assert np.array_equal(out.cfg["a"], self.a)
+                assert set(["a"]) == set(cr_cfg.keys())
+                assert np.array_equal(cr_cfg["a"], self.a)
                 assert len(out.trials) == len(sel.trials)
                 # ensure our `log_dict` specification was respected
                 assert "lowpass" in out._log
@@ -471,8 +474,8 @@ class TestComputationalRoutine():
                     fname = os.path.join(tdir, "dummy")
                     out.save(fname)
                     dummy = load(fname)
-                    assert "a" in dummy.cfg.keys()
-                    assert np.array_equal(dummy.cfg["a"], self.a)
+                    assert "a" in dummy.cfg['LowPassFilter'].keys()
+                    assert np.array_equal(dummy.cfg['LowPassFilter']["a"], self.a)
                     assert out.filename == dummy.filename
                     assert not out.data.is_virtual
                     if select is None:
@@ -491,8 +494,8 @@ class TestComputationalRoutine():
                     fname2 = os.path.join(tdir, "dummy2")
                     out_sel.save(fname2)
                     dummy2 = load(fname2)
-                    assert "a" in dummy2.cfg.keys()
-                    assert np.array_equal(dummy2.cfg["a"], dummy.cfg["a"])
+                    assert "a" in dummy2.cfg['LowPassFilter'].keys()
+                    assert np.array_equal(dummy2.cfg['LowPassFilter']["a"], dummy.cfg['LowPassFilter']["a"])
                     assert np.array_equal(dummy.data, dummy2.data)
                     assert np.array_equal(dummy.channel, dummy2.channel)
                     assert np.array_equal(dummy.time, dummy2.time)

--- a/syncopy/tests/test_computationalroutine.py
+++ b/syncopy/tests/test_computationalroutine.py
@@ -235,11 +235,6 @@ class TestComputationalRoutine():
             out = filter_manager(self.sigdata, self.b, self.a, select=select,
                                  log_dict={"a": "this is a", "b": "this is b"})
 
-            # access the cfg belonging to the (single) CR
-            cr_cfg = out.cfg['LowPassFilter']
-            # only keyword args (`a` in this case here) are stored in `cfg`
-            assert set(["a"]) == set(cr_cfg.keys())
-            assert np.array_equal(cr_cfg["a"], self.a)
             assert len(out.trials) == len(sel.trials)
             # ensure our `log_dict` specification was respected
             assert "lowpass" in out._log
@@ -253,8 +248,6 @@ class TestComputationalRoutine():
                 selected = self.sigdata.selectdata(**select)
             out_sel = filter_manager(selected, self.b, self.a,
                                      log_dict={"a": "this is a", "b": "this is b"})
-            assert set(["a"]) == set(cr_cfg.keys())
-            assert np.array_equal(cr_cfg["a"], self.a)
             assert len(out.trials) == len(out_sel.trials)
             assert "lowpass" in out._log
             assert "a = this is a" in out._log
@@ -265,8 +258,6 @@ class TestComputationalRoutine():
                 fname = os.path.join(tdir, "dummy")
                 out.save(fname)
                 dummy = load(fname)
-                assert "a" in dummy.cfg['LowPassFilter'].keys()
-                assert np.array_equal(dummy.cfg['LowPassFilter']["a"], self.a)
                 assert out.filename == dummy.filename
                 if select is None:
                     reference = self.orig
@@ -285,8 +276,6 @@ class TestComputationalRoutine():
                 fname2 = os.path.join(tdir, "dummy2")
                 out_sel.save(fname2)
                 dummy2 = load(fname2)
-                assert "a" in dummy2.cfg['LowPassFilter'].keys()
-                assert np.array_equal(dummy2.cfg['LowPassFilter']["a"], dummy.cfg['LowPassFilter']["a"])
                 assert np.array_equal(dummy.data, dummy2.data)
                 assert np.array_equal(dummy.channel, dummy2.channel)
                 assert np.array_equal(dummy.time, dummy2.time)
@@ -441,11 +430,7 @@ class TestComputationalRoutine():
                 out = filter_manager(self.sigdata, self.b, self.a, select=select,
                                      log_dict={"a": "this is a", "b": "this is b"},
                                      parallel=True, parallel_store=parallel_store)
-                
-                cr_cfg = out.cfg['LowPassFilter']
-                # only keyword args (`a` in this case here) are stored in `cfg`
-                assert set(["a"]) == set(cr_cfg.keys())
-                assert np.array_equal(cr_cfg["a"], self.a)
+
                 assert len(out.trials) == len(sel.trials)
                 # ensure our `log_dict` specification was respected
                 assert "lowpass" in out._log
@@ -461,8 +446,6 @@ class TestComputationalRoutine():
                                          log_dict={"a": "this is a", "b": "this is b"},
                                          parallel=True, parallel_store=parallel_store)
                 # only keyword args (`a` in this case here) are stored in `cfg`
-                assert set(["a"]) == set(cr_cfg.keys())
-                assert np.array_equal(cr_cfg["a"], self.a)
                 assert len(out.trials) == len(sel.trials)
                 # ensure our `log_dict` specification was respected
                 assert "lowpass" in out._log
@@ -474,8 +457,6 @@ class TestComputationalRoutine():
                     fname = os.path.join(tdir, "dummy")
                     out.save(fname)
                     dummy = load(fname)
-                    assert "a" in dummy.cfg['LowPassFilter'].keys()
-                    assert np.array_equal(dummy.cfg['LowPassFilter']["a"], self.a)
                     assert out.filename == dummy.filename
                     assert not out.data.is_virtual
                     if select is None:
@@ -494,8 +475,6 @@ class TestComputationalRoutine():
                     fname2 = os.path.join(tdir, "dummy2")
                     out_sel.save(fname2)
                     dummy2 = load(fname2)
-                    assert "a" in dummy2.cfg['LowPassFilter'].keys()
-                    assert np.array_equal(dummy2.cfg['LowPassFilter']["a"], dummy.cfg['LowPassFilter']["a"])
                     assert np.array_equal(dummy.data, dummy2.data)
                     assert np.array_equal(dummy.channel, dummy2.channel)
                     assert np.array_equal(dummy.time, dummy2.time)

--- a/syncopy/tests/test_continuousdata.py
+++ b/syncopy/tests/test_continuousdata.py
@@ -30,11 +30,11 @@ skip_without_acme = pytest.mark.skipif(
     not __acme__, reason="acme not available")
 
 # Collect all supported binary arithmetic operators
-arithmetics = [lambda x, y : x + y,
-               lambda x, y : x - y,
-               lambda x, y : x * y,
-               lambda x, y : x / y,
-               lambda x, y : x ** y]
+arithmetics = [lambda x, y: x + y,
+               lambda x, y: x - y,
+               lambda x, y: x * y,
+               lambda x, y: x / y,
+               lambda x, y: x ** y]
 
 # Module-wide set of testing selections
 trialSelections = [
@@ -46,29 +46,29 @@ chanSelections = [
     [4, 2, 2, 5, 5],   # repetition + unordered
     range(5, 8),  # narrow range
     slice(-2, None),  # negative-start slice
-    "channel02", # str selection
+    "channel02",  # str selection
     1  # scalar selection
-    ]
+]
 toiSelections = [
     "all",  # non-type-conform string
     0.6,  # single inexact match
     [-0.2, 0.6, 0.9, 1.1, 1.3, 1.6, 1.8, 2.2, 2.45, 3.]  # unordered, inexact, repetions
-    ]
+]
 toilimSelections = [
     [0.5, 1.5],  # regular range
     [1.5, 2.0],  # minimal range (just two-time points)
     [1.0, np.inf]  # unbounded from above
-    ]
+]
 foiSelections = [
     "all",  # non-type-conform string
     2.6,  # single inexact match
     [1.1, 1.9, 2.1, 3.9, 9.2, 11.8, 12.9, 5.1, 13.8]  # unordered, inexact, repetions
-    ]
+]
 foilimSelections = [
     [2, 11],  # regular range
     [1, 2.0],  # minimal range (just two-time points)
     [1.0, np.inf]  # unbounded from above
-    ]
+]
 taperSelections = [
     ["TestTaper_03", "TestTaper_01", "TestTaper_01", "TestTaper_02"],  # string selection w/repetition + unordered
     "TestTaper_03",  # singe str
@@ -76,11 +76,12 @@ taperSelections = [
     [0, 1, 1, 2, 3],  # preserve repetition, don't convert to slice
     range(2, 5),  # narrow range
     slice(0, 5, 2),  # slice w/non-unitary step-size
-    ]
+]
 timeSelections = list(zip(["toi"] * len(toiSelections), toiSelections)) \
     + list(zip(["toilim"] * len(toilimSelections), toilimSelections))
 freqSelections = list(zip(["foi"] * len(foiSelections), foiSelections)) \
     + list(zip(["foilim"] * len(foilimSelections), foilimSelections))
+
 
 # Local helper function for performing basic arithmetic tests
 def _base_op_tests(dummy, ymmud, dummy2, ymmud2, dummyC, operation):
@@ -95,24 +96,24 @@ def _base_op_tests(dummy, ymmud, dummy2, ymmud2, dummyC, operation):
     dummy2.selectdata(trials=0, inplace=True)
     with pytest.raises(SPYValueError) as spyval:
         operation(dummy, dummy2)
-        assert "Syncopy object with same number of trials (selected)" in str (spyval.value)
+        assert "Syncopy object with same number of trials (selected)" in str(spyval.value)
     dummy2.selection = None
 
     # Scalar algebra must be commutative (except for pow)
     for operand in scalarOperands:
-        result = operation(dummy, operand) # perform operation from right
+        result = operation(dummy, operand)  # perform operation from right
         for tk, trl in enumerate(result.trials):
             assert np.array_equal(trl, operation(dummy.trials[tk], operand))
         # Don't try to compute `2 ** data``
-        if operation(2,3) != 8:
-            result2 = operation(operand, dummy) # perform operation from left
+        if operation(2, 3) != 8:
+            result2 = operation(operand, dummy)  # perform operation from left
             assert np.array_equal(result2.data, result.data)
 
         # Same as above, but swapped `dimord`
         result = operation(ymmud, operand)
         for tk, trl in enumerate(result.trials):
             assert np.array_equal(trl, operation(ymmud.trials[tk], operand))
-        if operation(2,3) != 8:
+        if operation(2, 3) != 8:
             result2 = operation(operand, ymmud)
             assert np.array_equal(result2.data, result.data)
 
@@ -144,6 +145,7 @@ def _base_op_tests(dummy, ymmud, dummy2, ymmud2, dummyC, operation):
     for tk, trl in enumerate(result.trials):
         assert np.array_equal(trl, operation(ymmud.trials[tk], ymmud2.trials[tk]))
 
+
 def _selection_op_tests(dummy, ymmud, dummy2, ymmud2, kwdict, operation):
 
     # Perform in-place selection and construct array based on new subset
@@ -169,14 +171,14 @@ def _selection_op_tests(dummy, ymmud, dummy2, ymmud2, kwdict, operation):
     if cleanSelection:
         for tk, trl in enumerate(result.trials):
             assert np.array_equal(trl, operation(selected.trials[tk],
-                                                selected.trials[tk]))
+                                                 selected.trials[tk]))
         selected = ymmud.selectdata(**kwdict)
         ymmud.selectdata(inplace=True, **kwdict)
         ymmud2.selectdata(inplace=True, **kwdict)
         result = operation(ymmud, ymmud2)
         for tk, trl in enumerate(result.trials):
             assert np.array_equal(trl, operation(selected.trials[tk],
-                                                selected.trials[tk]))
+                                                 selected.trials[tk]))
 
     # Very important: clear manually set selections for next iteration
     dummy.selection = None
@@ -200,7 +202,7 @@ class TestAnalogData():
     def test_empty(self):
         dummy = AnalogData()
         assert len(dummy.cfg) == 0
-        assert dummy.dimord == None
+        assert dummy.dimord is None
         for attr in ["channel", "data", "hdr", "sampleinfo", "trialinfo"]:
             assert getattr(dummy, attr) is None
         with pytest.raises(SPYTypeError):
@@ -474,7 +476,7 @@ class TestAnalogData():
 
         # construct AnalogData object w/trials of unequal lengths
         adata = generate_artificial_data(nTrials=7, nChannels=16,
-                                        equidistant=False, inmemory=False)
+                                         equidistant=False, inmemory=False)
         timeAxis = adata.dimord.index("time")
         chanAxis = adata.dimord.index("channel")
 
@@ -494,7 +496,7 @@ class TestAnalogData():
             assert trl_time - total_time < 1 / adata.samplerate
 
         # real thing: pad object with standing channel selection
-        res = padding(adata, "zero", pad="absolute", padlength=total_time,unit="time",
+        res = padding(adata, "zero", pad="absolute", padlength=total_time, unit="time",
                       create_new=True, select={"trials": trialSel, "channel": chanSel})
         for tk, trl in enumerate(res.trials):
             adataTrl = adata.trials[trialSel[tk]]
@@ -634,11 +636,10 @@ class TestAnalogData():
                             assert np.array_equal(selected.trials[tk].squeeze(),
                                                   obj.trials[trialno][idx[0], :][:, idx[1]].squeeze())
                         cfg.data = obj
-                        cfg.out = AnalogData(dimord=obj.dimord)
                         # data selection via package function and `cfg`: ensure equality
-                        selectdata(cfg)
-                        assert np.array_equal(cfg.out.channel, selected.channel)
-                        assert np.array_equal(cfg.out.data, selected.data)
+                        out = selectdata(cfg)
+                        assert np.array_equal(out.channel, selected.channel)
+                        assert np.array_equal(out.data, selected.data)
                         time.sleep(0.001)
 
     # test arithmetic operations
@@ -666,7 +667,7 @@ class TestAnalogData():
             # First, ensure `dimord` is respected
             with pytest.raises(SPYValueError) as spyval:
                 operation(dummy, ymmud)
-                assert "expected Syncopy 'time' x 'channel' data object" in str (spyval.value)
+                assert "expected Syncopy 'time' x 'channel' data object" in str(spyval.value)
 
             _base_op_tests(dummy, ymmud, dummy2, ymmud2, None, operation)
 
@@ -732,7 +733,7 @@ class TestSpectralData():
     def test_sd_empty(self):
         dummy = SpectralData()
         assert len(dummy.cfg) == 0
-        assert dummy.dimord == None
+        assert dummy.dimord is None
         for attr in ["channel", "data", "freq", "sampleinfo", "taper", "trialinfo"]:
             assert getattr(dummy, attr) is None
         with pytest.raises(SPYTypeError):
@@ -872,15 +873,14 @@ class TestSpectralData():
                                     idx[timeIdx] = selector.time[tk]
                                     indexed = obj.trials[trialno][idx[0], ...][:, idx[1], ...][:, :, idx[2], :][..., idx[3]]
                                     assert np.array_equal(selected.trials[tk].squeeze(),
-                                                        indexed.squeeze())
+                                                          indexed.squeeze())
                                 cfg.data = obj
-                                cfg.out = SpectralData(dimord=obj.dimord)
                                 # data selection via package function and `cfg`: ensure equality
-                                selectdata(cfg)
-                                assert np.array_equal(cfg.out.channel, selected.channel)
-                                assert np.array_equal(cfg.out.freq, selected.freq)
-                                assert np.array_equal(cfg.out.taper, selected.taper)
-                                assert np.array_equal(cfg.out.data, selected.data)
+                                out = selectdata(cfg)
+                                assert np.array_equal(out.channel, selected.channel)
+                                assert np.array_equal(out.freq, selected.freq)
+                                assert np.array_equal(out.taper, selected.taper)
+                                assert np.array_equal(out.data, selected.data)
                                 time.sleep(0.001)
 
     # test arithmetic operations
@@ -946,7 +946,6 @@ class TestSpectralData():
                 kwdict["taper"] = taperSelections[2]
                 _selection_op_tests(dummy, ymmud, dummy2, ymmud2, kwdict, operation)
 
-
         # Finally, perform a representative chained operation to ensure chaining works
         result = (dummy + dummy2) / dummy ** 3
         for tk, trl in enumerate(result.trials):
@@ -984,7 +983,7 @@ class TestCrossSpectralData():
     def test_csd_empty(self):
         dummy = CrossSpectralData()
         assert len(dummy.cfg) == 0
-        assert dummy.dimord == None
+        assert dummy.dimord is None
         for attr in ["channel_i", "channel_j", "data", "freq", "sampleinfo", "trialinfo"]:
             assert getattr(dummy, attr) is None
         with pytest.raises(SPYTypeError):
@@ -1059,8 +1058,8 @@ class TestCrossSpectralData():
             filename = construct_spy_filename(fname + "_dimswap", dummy)
             dummy2 = load(filename)
             assert dummy2.dimord == dummy.dimord
-            assert dummy2.channel_i.size == self.nci # swapped
-            assert dummy2.channel_j.size == self.nf # swapped
+            assert dummy2.channel_i.size == self.nci  # swapped
+            assert dummy2.channel_j.size == self.nf  # swapped
             assert dummy2.freq.size == self.ns  # swapped
             assert dummy2.data.shape == dummy.data.shape
 
@@ -1124,13 +1123,12 @@ class TestCrossSpectralData():
                                     assert np.array_equal(selected.trials[tk].squeeze(),
                                                           indexed.squeeze())
                                 cfg.data = obj
-                                cfg.out = CrossSpectralData(dimord=obj.dimord)
                                 # data selection via package function and `cfg`: ensure equality
-                                selectdata(cfg)
-                                assert np.array_equal(cfg.out.channel_i, selected.channel_i)
-                                assert np.array_equal(cfg.out.channel_j, selected.channel_j)
-                                assert np.array_equal(cfg.out.freq, selected.freq)
-                                assert np.array_equal(cfg.out.data, selected.data)
+                                out = selectdata(cfg)
+                                assert np.array_equal(out.channel_i, selected.channel_i)
+                                assert np.array_equal(out.channel_j, selected.channel_j)
+                                assert np.array_equal(out.freq, selected.freq)
+                                assert np.array_equal(out.data, selected.data)
                                 time.sleep(0.001)
 
     # test arithmetic operations

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -170,21 +170,21 @@ class TestSpikeData():
             [4, 2, 2, 5, 5],   # repetition + unorderd
             range(5, 8),  # narrow range
             slice(-5, None)  # negative-start slice
-            ]
+        ]
         toiSelections = [
             "all",  # non-type-conform string
             [-0.2, 0.6, 0.9, 1.1, 1.3, 1.6, 1.8, 2.2, 2.45, 3.]  # unordered, inexact, repetions
-            ]
+        ]
         toilimSelections = [
             [0.5, 3.5],  # regular range
             [1.0, np.inf]  # unbounded from above
-            ]
+        ]
         unitSelections = [
             ["unit1", "unit1", "unit2", "unit3"],  # preserve repetition
             [0, 0, 2, 3],  # preserve repetition, don't convert to slice
             range(1, 4),  # narrow range
             slice(-2, None)  # negative-start slice
-            ]
+        ]
         timeSelections = list(zip(["toi"] * len(toiSelections), toiSelections)) \
             + list(zip(["toilim"] * len(toilimSelections), toilimSelections))
 
@@ -221,19 +221,18 @@ class TestSpikeData():
                             for trialno in selector.trials:
                                 if selector.time[tk]:
                                     assert np.array_equal(obj.trials[trialno][selector.time[tk], :],
-                                                        selected.trials[tk])
+                                                          selected.trials[tk])
                                     tk += 1
                             assert set(selected.data[:, chanIdx]).issubset(chanArr[selector.channel])
                             assert set(selected.channel) == set(obj.channel[selector.channel])
                             assert np.array_equal(selected.unit,
-                                                obj.unit[np.unique(selected.data[:, unitIdx])])
+                                                  obj.unit[np.unique(selected.data[:, unitIdx])])
                             cfg.data = obj
-                            cfg.out = SpikeData(dimord=obj.dimord)
                             # data selection via package function and `cfg`: ensure equality
-                            selectdata(cfg)
-                            assert np.array_equal(cfg.out.channel, selected.channel)
-                            assert np.array_equal(cfg.out.unit, selected.unit)
-                            assert np.array_equal(cfg.out.data, selected.data)
+                            out = selectdata(cfg)
+                            assert np.array_equal(out.channel, selected.channel)
+                            assert np.array_equal(out.unit, selected.unit)
+                            assert np.array_equal(out.data, selected.data)
 
     @skip_without_acme
     def test_parallel(self, testcluster, fulltests):
@@ -244,6 +243,7 @@ class TestSpikeData():
             getattr(self, test)(fulltests)
             flush_local_cluster(testcluster)
         client.close()
+
 
 class TestEventData():
 
@@ -270,7 +270,7 @@ class TestEventData():
     def test_ed_empty(self):
         dummy = EventData()
         assert len(dummy.cfg) == 0
-        assert dummy.dimord == None
+        assert dummy.dimord is None
         for attr in ["data", "sampleinfo", "samplerate", "trialid", "trialinfo"]:
             assert getattr(dummy, attr) is None
         with pytest.raises(SPYTypeError):
@@ -366,7 +366,7 @@ class TestEventData():
             filename = construct_spy_filename(fname + "_dimswap", dummy)
             dummy2 = load(filename)
             assert dummy2.dimord == dummy.dimord
-            assert dummy2.eventid.size == self.num_smp # swapped
+            assert dummy2.eventid.size == self.num_smp  # swapped
             assert dummy2.data.shape == dummy.data.shape
             del dummy, dummy2
 
@@ -469,7 +469,7 @@ class TestEventData():
         evt_dummy = EventData(data=data4, dimord=self.customDimord, samplerate=sr_e)
         evt_dummy.definetrial(pre=pre, post=post, trigger=1)
         # with pytest.raises(SPYValueError):
-            # ang_dummy.definetrial(evt_dummy)
+        # ang_dummy.definetrial(evt_dummy)
 
         # Trimming edges produces zero-length trial
         with pytest.raises(SPYValueError):
@@ -481,7 +481,7 @@ class TestEventData():
         evt_dummy = EventData(data=data4, dimord=self.customDimord, samplerate=sr_e)
         evt_dummy.definetrial(pre=pre, post=post, trigger=1)
         # with pytest.raises(SPYValueError):
-            # ang_dummy.definetrial(evt_dummy)
+        # ang_dummy.definetrial(evt_dummy)
         ang_dummy.definetrial(evt_dummy, clip_edges=True)
         assert ang_dummy.sampleinfo[-1, 1] == self.ns
 
@@ -539,15 +539,15 @@ class TestEventData():
             [0, 0, 1],  # preserve repetition, don't convert to slice
             range(0, 2),  # narrow range
             slice(-2, None)  # negative-start slice
-            ]
+        ]
         toiSelections = [
             "all",  # non-type-conform string
             [-0.2, 0.6, 0.9, 1.1, 1.3, 1.6, 1.8, 2.2, 2.45, 3.]  # unordered, inexact, repetions
-            ]
+        ]
         toilimSelections = [
             [0.5, 3.5],  # regular range
             [0.0, np.inf]  # unbounded from above
-            ]
+        ]
         timeSelections = list(zip(["toi"] * len(toiSelections), toiSelections)) \
             + list(zip(["toilim"] * len(toilimSelections), toilimSelections))
 
@@ -578,16 +578,15 @@ class TestEventData():
                         for trialno in selector.trials:
                             if selector.time[tk]:
                                 assert np.array_equal(obj.trials[trialno][selector.time[tk], :],
-                                                    selected.trials[tk])
+                                                      selected.trials[tk])
                                 tk += 1
                         assert np.array_equal(selected.eventid,
-                                            obj.eventid[np.unique(selected.data[:, eventidIdx]).astype(np.intp)])
+                                              obj.eventid[np.unique(selected.data[:, eventidIdx]).astype(np.intp)])
                         cfg.data = obj
-                        cfg.out = EventData(dimord=obj.dimord)
                         # data selection via package function and `cfg`: ensure equality
-                        selectdata(cfg)
-                        assert np.array_equal(cfg.out.eventid, selected.eventid)
-                        assert np.array_equal(cfg.out.data, selected.data)
+                        out = selectdata(cfg)
+                        assert np.array_equal(out.eventid, selected.eventid)
+                        assert np.array_equal(out.data, selected.data)
 
     @skip_without_acme
     def test_ed_parallel(self, testcluster, fulltests):

--- a/syncopy/tests/test_specest.py
+++ b/syncopy/tests/test_specest.py
@@ -170,48 +170,6 @@ class TestMTMFFT():
                                 output="pow", select=select)
             assert "float" in spec.data.dtype.name
 
-
-    def test_allocout(self):
-        # call `freqanalysis` w/pre-allocated output object
-        out = SpectralData(dimord=SpectralData._defaultDimord)
-        freqanalysis(self.adata, method="mtmfft", taper="hann", out=out)
-        assert len(out.trials) == self.nTrials
-        assert out.taper.size == 1
-        assert out.freq.size == self.fband.size + 1
-        assert np.allclose([0] + self.fband.tolist(), out.freq)
-        assert out.channel.size == self.nChannels
-
-        # build `cfg` object for calling
-        cfg = StructDict()
-        cfg.method = "mtmfft"
-        cfg.taper = "hann"
-        cfg.keeptrials = "no"
-        cfg.output = "abs"
-        cfg.out = SpectralData(dimord=SpectralData._defaultDimord)
-
-        # throw away trials
-        freqanalysis(self.adata, cfg)
-        assert len(cfg.out.time) == 1
-        assert len(cfg.out.time[0]) == 1
-        assert np.all(cfg.out.sampleinfo == [0, 1])
-        assert cfg.out.data.shape[0] == 1  # ensure trial-count == 1
-
-        # keep trials but throw away tapers
-        out = SpectralData(dimord=SpectralData._defaultDimord)
-        freqanalysis(self.adata, method="mtmfft",
-                     tapsmofrq=3, keeptapers=False, output="pow", out=out)
-        assert out.sampleinfo.shape == (self.nTrials, 2)
-        assert out.taper.size == 1
-
-        # re-use `cfg` from above and additionally throw away `tapers`
-        cfg.dataset = self.adata
-        cfg.out = SpectralData(dimord=SpectralData._defaultDimord)
-        cfg.tapsmofrq = 3
-        cfg.output = "pow"
-        cfg.keeptapers = False
-        freqanalysis(cfg)
-        assert cfg.out.taper.size == 1
-
     def test_solution(self):
         # ensure channel-specific frequencies are identified correctly
         for sk, select in enumerate(self.sigdataSelections):
@@ -523,51 +481,6 @@ class TestMTMConvol():
                 cfg.toi = np.linspace(-2, 6, 5)
                 tfSpec = freqanalysis(cfg, _make_tf_signal(2, 2, self.seed, fadeIn=self.fadeIn, fadeOut=self.fadeOut)[0])
                 assert outputDict[cfg.output] in tfSpec.data.dtype.name
-
-    def test_tf_allocout(self):
-        # use `mtmconvol` w/pre-allocated output object
-        out = SpectralData(dimord=SpectralData._defaultDimord)
-        freqanalysis(self.tfData, method="mtmconvol", taper="hann", toi=0.0,
-                     t_ftimwin=1.0, out=out)
-        assert len(out.trials) == len(self.tfData.trials)
-        assert out.taper.size == 1
-        assert out.freq.size == self.tfData.samplerate / 2 + 1
-        assert out.channel.size == self.nChannels
-
-        # build `cfg` object for calling
-        cfg = StructDict()
-        cfg.method = "mtmconvol"
-        cfg.taper = "hann"
-        cfg.keeptrials = "no"
-        cfg.output = "abs"
-        cfg.toi = 0.0
-        cfg.t_ftimwin = 1.0
-        cfg.out = SpectralData(dimord=SpectralData._defaultDimord)
-
-        # throw away trials: computing `trLen` this way only works for non-overlapping windows!
-        freqanalysis(self.tfData, cfg)
-        assert len(cfg.out.time) == 1
-        trLen = len(self.tfData.time[0]) / (cfg.t_ftimwin * self.tfData.samplerate)
-        assert len(cfg.out.time[0]) == trLen
-        assert np.all(cfg.out.sampleinfo == [0, trLen])
-        assert cfg.out.data.shape[0] == trLen  # ensure trial-count == 1
-
-        # keep trials but throw away tapers
-        out = SpectralData(dimord=SpectralData._defaultDimord)
-        freqanalysis(self.tfData, method="mtmconvol", tapsmofrq=3,
-                     keeptapers=False, output="pow", toi=0.0, t_ftimwin=1.0,
-                     out=out)
-        assert out.sampleinfo.shape == (self.nTrials, 2)
-        assert out.taper.size == 1
-
-        # re-use `cfg` from above and additionally throw away `tapers`
-        cfg.dataset = self.tfData
-        cfg.out = SpectralData(dimord=SpectralData._defaultDimord)
-        cfg.tapsmofrq = 3
-        cfg.keeptapers = False
-        cfg.output = "pow"
-        freqanalysis(cfg)
-        assert cfg.out.taper.size == 1
 
     def test_tf_solution(self):
         # Compute "full" non-overlapping TF spectrum, i.e., center analysis windows

--- a/syncopy/tests/test_spyio.py
+++ b/syncopy/tests/test_spyio.py
@@ -76,7 +76,7 @@ class TestSpyIO():
     # Define data classes to be used in tests below
     classes = ["AnalogData", "SpectralData", "CrossSpectralData", "SpikeData", "EventData"]
 
-    # Test correct handling of object log and cfg
+    # Test correct handling of object log
     def test_logging(self):
         with tempfile.TemporaryDirectory() as tdir:
             fname = os.path.join(tdir, "dummy")
@@ -88,18 +88,12 @@ class TestSpyIO():
             assert len(dummy._log) > ldum
             assert dummy.filename in dummy._log
             assert dummy.filename + FILE_EXT["info"] in dummy._log
-            assert dummy.cfg["method"] == "save"
-            assert dummy.filename in dummy.cfg["files"]
-            assert dummy.filename + FILE_EXT["info"] in dummy.cfg["files"]
 
             # ensure loading is logged correctly
             dummy2 = load(filename=fname + ".analog")
             assert len(dummy2._log) > len(dummy._log)
             assert dummy2.filename in dummy2._log
             assert dummy2.filename + FILE_EXT["info"] in dummy._log
-            assert dummy2.cfg.cfg["method"] == "load"
-            assert dummy2.filename in dummy2.cfg.cfg["files"]
-            assert dummy2.filename + FILE_EXT["info"] in dummy2.cfg.cfg["files"]
 
             # Delete all open references to file objects b4 closing tmp dir
             del dummy, dummy2


### PR DESCRIPTION
## Reworked `cfg` attribute

Instead of CRs writing to the `out.cfg` object, let the frontends collect all passed parameters to finally allow for the desired **replay functionality**:
```python
res1 = spy.freqanalysis(input, cfg=...)
# same cfg
res2 = spy.freqanalysis(input, cfg=res1.cfg)
```
addresse #209 

EDIT: Also removed pre-allocated output option for `freqanalysis` (only frontend which supported this anyways..)

Author Guidelines
-----------------
- [x] Is the change set **< 400 lines**?
- [x] Was the code checked for memory leaks/performance bottlenecks?
- [x] Is the code running locally **and** on the ESI cluster?
- [x] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [ ] Are testing routines present? `cfg` save/load potentially missing
- [x] Do **parallel** loops have a set length and correct termination conditions?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [x] Code layout
  - [x] Is the code PEP8 compliant?
  - [x] Does the code adhere to agreed-upon naming conventions?
  - [x] Are keywords clearly named and easy to understand?
  - [x] No commented-out code?
- [x] Are all docstrings complete and accurate?
