### PR TITLE
303 auxiliary meta info container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ### NEW
 - Added down- and resampling algorithms for the new meta-function `resampledata`
 - new global `spy.copy()` function which copies entire Syncopy objects on disk
+- Added `.info` attribute for all data classes to store auxiliary meta information
 
 ### CHANGED
 - the `out.cfg` attached to an analysis result now allows to replay all analysis methods

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -59,7 +59,7 @@ class BaseData(ABC):
     """
 
     #: properties that are written into the JSON file and HDF5 attributes upon save
-    _infoFileProperties = ("dimord", "_version", "_log", "cfg",)
+    _infoFileProperties = ("dimord", "_version", "_log", "cfg", "info")
     _hdfFileAttributeProperties = ("dimord", "_version", "_log",)
 
     #: properties that are mapped onto HDF5 datasets
@@ -123,10 +123,29 @@ class BaseData(ABC):
 
     @cfg.setter
     def cfg(self, dct):
-        """ For loading only, for processing the CR extends the existing (empty) cfg dictionary """
+        """ For loading only, for processing the frontends
+        extend the existing (empty) cfg dictionary """
+
         if not isinstance(dct, dict):
             raise SPYTypeError(dct, varname="cfg", expected="dictionary-like object")
         self._cfg = dct
+
+    @property
+    def info(self):
+        """Dictionary of auxiliary meta information"""
+        return self._info
+
+    @info.setter
+    def info(self, dct):
+
+        """
+        Users usually want to extend the existing info dictionary,
+        however it is possible to completely overwrite with a new dict
+        """
+
+        if not isinstance(dct, dict):
+            raise SPYTypeError(dct, varname="info", expected="dictionary-like object")
+        self._info = dct
 
     @property
     def container(self):
@@ -889,6 +908,7 @@ class BaseData(ABC):
 
         # each instance needs its own cfg!
         self._cfg = {}
+        self._info = {}
 
         # Initialize hidden attributes
         for propertyName in self._hdfFileDatasetProperties:

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -25,6 +25,7 @@ import syncopy as spy
 from .methods.arithmetic import _process_operator
 from .methods.selectdata import selectdata
 from .methods.show import show
+from syncopy.shared.tools import SerializableDict
 from syncopy.shared.parsers import (scalar_parser, array_parser, io_parser,
                                     filename_parser, data_parser)
 from syncopy.shared.errors import SPYInfo, SPYTypeError, SPYValueError, SPYError
@@ -142,7 +143,8 @@ class BaseData(ABC):
 
         if not isinstance(dct, dict):
             raise SPYTypeError(dct, varname="info", expected="dictionary-like object")
-        self._info = dct
+
+        self._info = SerializableDict(dct)
 
     @property
     def container(self):
@@ -893,7 +895,7 @@ class BaseData(ABC):
 
         # each instance needs its own cfg!
         self._cfg = {}
-        self._info = {}
+        self._info = SerializableDict()
 
         # Initialize hidden attributes
         for propertyName in self._hdfFileDatasetProperties:

--- a/syncopy/shared/tools.py
+++ b/syncopy/shared/tools.py
@@ -6,6 +6,7 @@
 # Builtin/3rd party package imports
 import numpy as np
 import inspect
+import json
 
 # Local imports
 from syncopy.shared.errors import SPYValueError, SPYWarning, SPYTypeError
@@ -45,6 +46,31 @@ class StructDict(dict):
         else:
             ppStr = "{}"
         return ppStr
+
+
+class SerializableDict(dict):
+
+    """
+    It's a dict which checks newly inserted
+    values for serializability, keys should always be serializable
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # check also initial entries
+        for key, value in self.items():
+            self.is_json(key, value)
+
+    def __setitem__(self, key, value):
+        self.is_json(key, value)
+        dict.__setitem__(self, key, value)
+
+    def is_json(self, key, value):
+        try:
+            json.dumps(value)
+        except TypeError:
+            lgl = "serializable data type, e.g. numbers, lists, tuples, ... "
+            raise SPYTypeError(value, f"value for key '{key}'", lgl)
 
 
 def get_frontend_cfg(defaults, lcls, kwargs):

--- a/syncopy/shared/tools.py
+++ b/syncopy/shared/tools.py
@@ -69,8 +69,13 @@ class SerializableDict(dict):
         try:
             json.dumps(value)
         except TypeError:
-            lgl = "serializable data type, e.g. numbers, lists, tuples, ... "
+            lgl = "serializable data type, e.g. floats, lists, tuples, ... "
             raise SPYTypeError(value, f"value for key '{key}'", lgl)
+        try:
+            json.dumps(key)
+        except TypeError:
+            lgl = "serializable data type, e.g. floats, lists, tuples, ... "
+            raise SPYTypeError(value, f"key '{key}'", lgl)
 
 
 def get_frontend_cfg(defaults, lcls, kwargs):

--- a/syncopy/specest/compRoutines.py
+++ b/syncopy/specest/compRoutines.py
@@ -189,13 +189,6 @@ class MultiTaperFFT(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
-        # only workd for parallel computing!!
-        print(5 * 'A',self.outFileName.format(0))
-        print(5 * 'A',self.outFileName.format(1))
-        print(self.numCalls)
-        #vsources = out.data.virtual_sources()
-        #print([source.file_name for source in vsources])
-
         # Some index gymnastics to get trial begin/end "samples"
         if data.selection is not None:
             chanSec = data.selection.channel

--- a/syncopy/tests/test_basedata.py
+++ b/syncopy/tests/test_basedata.py
@@ -187,6 +187,10 @@ class TestBaseData():
                 dummy = getattr(spd, dclass)(data=h5py.File(hname, 'r')["dummy"],
                                              samplerate=self.samplerate)
 
+                # attach some aux. info
+                dummy.info = {'sth': 4, 'important': [1, 2],
+                              'to-remember': {'v1': 2}}
+
                 # test integrity of deep-copy
                 dummy.trialdefinition = self.trl[dclass]
                 dummy2 = dummy.copy()
@@ -196,6 +200,7 @@ class TestBaseData():
                 assert np.array_equal(dummy.trialinfo, dummy2.trialinfo)
                 assert np.array_equal(dummy.data, dummy2.data)
                 assert dummy.samplerate == dummy2.samplerate
+                assert dummy.info == dummy2.info
 
                 # Delete all open references to file objects b4 closing tmp dir
                 del dummy, dummy2

--- a/syncopy/tests/test_info.py
+++ b/syncopy/tests/test_info.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Test .info property of BaseData
+#
+
+import pytest
+import numpy as np
+import tempfile
+import os
+
+# Local imports
+import syncopy as spy
+from syncopy.shared.tools import SerializableDict
+from syncopy.shared.errors import SPYTypeError
+
+
+class TestInfo:
+
+    # serializable dict
+    ok_dict = {'sth': 4, 'important': [1, 2],
+               'to': {'v1': 2}, 'remember': 'need more coffe'}
+    # non-serializable dict
+    ns_dict = {'sth': 4, 'not_serializable': {'v1': range(2)}}
+
+    # test setter
+    def test_property(self):
+
+        # as .info is a basedata property,
+        # testing for one derived class should suffice
+        adata = spy.AnalogData([np.ones((3, 1))], samplerate=1)
+
+        # attach some aux. info
+        adata.info = self.ok_dict
+
+        # got converted into SerializableDict
+        # so testing this makes sense
+        assert isinstance(adata.info, SerializableDict)
+        assert adata.info == self.ok_dict
+
+        # that is not allowed (akin to cfg)
+        with pytest.raises(SPYTypeError, match="expected dictionary-like"):
+            adata.info = None
+
+        # clear with empty dict
+        adata.info = {}
+        assert len(adata.info) == 0
+        assert len(self.ok_dict) != 0
+
+        # test we're catching non-serializable dictionary entries
+        with pytest.raises(SPYTypeError, match="expected serializable data type"):
+            adata.info['new-var'] = np.arange(3)
+        with pytest.raises(SPYTypeError, match="expected serializable data type"):
+            adata.info = self.ns_dict
+
+        # this interestingly still does NOT work (numbers are np.float64):
+        with pytest.raises(SPYTypeError, match="expected serializable data type"):
+            adata.info['new-var'] = list(np.arange(3))
+
+        # even this.. numbers are still np.int64
+        with pytest.raises(SPYTypeError, match="expected serializable data type"):
+            adata.info['new-var'] = list(np.arange(3, dtype=int))
+
+        # this then works, hope is that users don't abuse it
+        adata.info['new-var'] = list(np.arange(3, dtype=float))
+        assert np.allclose(adata.info['new-var'], np.arange(3))
+
+    # test aux. info dict saving and loading
+    def test_io(self):
+        with tempfile.TemporaryDirectory() as tdir:
+
+            fname = os.path.join(tdir, "dummy")
+            dummy = spy.AnalogData([np.ones((3, 1))], samplerate=1)
+
+            # attach some aux. info
+            dummy.info = self.ok_dict
+            spy.save(dummy, fname)
+            del dummy
+
+            dummy2 = spy.load(fname)
+            assert dummy2.info == self.ok_dict
+
+
+if __name__ == '__main__':
+    T1 = TestInfo()

--- a/syncopy/tests/test_info.py
+++ b/syncopy/tests/test_info.py
@@ -21,6 +21,8 @@ class TestInfo:
                'to': {'v1': 2}, 'remember': 'need more coffe'}
     # non-serializable dict
     ns_dict = {'sth': 4, 'not_serializable': {'v1': range(2)}}
+    # dict with non-serializable keys
+    ns_dict2 = {range(2) : 'small_range', range(1000) : 'large_range'}
 
     # test setter
     def test_property(self):
@@ -51,6 +53,10 @@ class TestInfo:
             adata.info['new-var'] = np.arange(3)
         with pytest.raises(SPYTypeError, match="expected serializable data type"):
             adata.info = self.ns_dict
+
+        # test that we also catch non-serializable keys
+        with pytest.raises(SPYTypeError, match="expected serializable data type"):
+            adata.info = self.ns_dict2
 
         # this interestingly still does NOT work (numbers are np.float64):
         with pytest.raises(SPYTypeError, match="expected serializable data type"):

--- a/syncopy/tests/test_spyio.py
+++ b/syncopy/tests/test_spyio.py
@@ -96,19 +96,6 @@ class TestSpyIO():
             # Delete all open references to file objects b4 closing tmp dir
             del dummy, dummy2
 
-    # test aux. info dict saving and loading
-    def test_info_property(self):
-        for dclass in self.classes:
-            with tempfile.TemporaryDirectory() as tdir:
-                fname = os.path.join(tdir, "dummy")
-                dummy = getattr(swd, dclass)(self.data[dclass], samplerate=1000)
-                # attach some aux. info
-                dummy.info = {'sth': 4, 'important': [1, 2],
-                              'to-remember': {'v1': 2}}
-                save(dummy, fname)
-                dummy2 = load(fname)
-                assert dummy2.info == dummy.info
-
     # Test consistency of generated checksums
     def test_checksum(self):
         with tempfile.TemporaryDirectory() as tdir:

--- a/syncopy/tests/test_spyio.py
+++ b/syncopy/tests/test_spyio.py
@@ -44,30 +44,30 @@ class TestSpyIO():
     trl = {}
 
     # Generate 2D array simulating an AnalogData array
-    data["AnalogData"] = np.arange(1, nc*ns + 1).reshape(ns, nc)
+    data["AnalogData"] = np.arange(1, nc * ns + 1).reshape(ns, nc)
     trl["AnalogData"] = np.vstack([np.arange(0, ns, 5),
                                    np.arange(5, ns + 5, 5),
-                                   np.ones((int(ns/5), )),
-                                   np.ones((int(ns/5), )) * np.pi]).T
+                                   np.ones((int(ns / 5), )),
+                                   np.ones((int(ns / 5), )) * np.pi]).T
 
     # Generate a 4D array simulating a SpectralData array
-    data["SpectralData"] = np.arange(1, nc*ns*nt*nf + 1).reshape(ns, nt, nc, nf)
+    data["SpectralData"] = np.arange(1, nc * ns * nt * nf + 1).reshape(ns, nt, nc, nf)
     trl["SpectralData"] = trl["AnalogData"]
 
     # Generate a 4D array simulating a CorssSpectralData array
-    data["CrossSpectralData"] = np.arange(1, nc*nc*ns*nf + 1).reshape(ns, nf, nc, nc)
+    data["CrossSpectralData"] = np.arange(1, nc * nc * ns * nf + 1).reshape(ns, nf, nc, nc)
     trl["CrossSpectralData"] = trl["AnalogData"]
 
     # Use a fixed random number generator seed to simulate a 2D SpikeData array
     seed = np.random.RandomState(13)
     data["SpikeData"] = np.vstack([seed.choice(ns, size=nd),
                                    seed.choice(nc, size=nd),
-                                   seed.choice(int(nc/2), size=nd)]).T
+                                   seed.choice(int(nc / 2), size=nd)]).T
     trl["SpikeData"] = trl["AnalogData"]
 
     # Generate bogus trigger timings
     data["EventData"] = np.vstack([np.arange(0, ns, 5),
-                                   np.zeros((int(ns/5), ))]).T
+                                   np.zeros((int(ns / 5), ))]).T
     data["EventData"][1::2, 1] = 1
     trl["EventData"] = trl["AnalogData"]
 
@@ -95,6 +95,19 @@ class TestSpyIO():
 
             # Delete all open references to file objects b4 closing tmp dir
             del dummy, dummy2
+
+    # test aux. info dict saving and loading
+    def test_info_property(self):
+        for dclass in self.classes:
+            with tempfile.TemporaryDirectory() as tdir:
+                fname = os.path.join(tdir, "dummy")
+                dummy = getattr(swd, dclass)(self.data[dclass], samplerate=1000)
+                # attach some aux. info
+                dummy.info = {'sth': 4, 'important': [1, 2],
+                              'to-remember': {'v1': 2}}
+                save(dummy, fname)
+                dummy2 = load(fname)
+                assert dummy2.info == dummy.info
 
     # Test consistency of generated checksums
     def test_checksum(self):


### PR DESCRIPTION
## New `.info` property for all Syncopy datatypes

- it's basically just a dict which gets saved as one of the `_infoFileProperties` into the json
- via `tools.SerializableDict` we hopefully discourage users from dumping huge arrays into this auxiliary dictionary

Author Guidelines
-----------------
- [x] Is the change set **< 600 lines**?
- [x] Was the code checked for memory leaks/performance bottlenecks?
- [x] Is the code running locally **and** on the ESI cluster?
- [x] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do **parallel** loops have a set length and correct termination conditions?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [x] Code layout
  - [x] Is the code PEP8 compliant?
  - [x] Does the code adhere to agreed-upon naming conventions?
  - [x] Are keywords clearly named and easy to understand?
  - [x] No commented-out code?
- [x] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
