### PR TITLE
FIX: Construct trialdefinition of resampled data

### DIFF
--- a/syncopy/tests/test_resampledata.py
+++ b/syncopy/tests/test_resampledata.py
@@ -28,7 +28,7 @@ skip_without_acme = pytest.mark.skipif(not __acme__, reason="acme not available"
 
 class TestDownsampling:
 
-    nSamples = 1000
+    nSamples = 991
     nChannels = 4
     nTrials = 100
     fs = 200
@@ -61,6 +61,10 @@ class TestDownsampling:
         if def_test:
             kwargs = {'resamplefs': self.fs // 2}
         ds = resampledata(self.adata, method='downsample', **kwargs)
+        lenTrials = np.diff(ds.sampleinfo).squeeze()
+        # check for equal trials
+        assert np.unique(lenTrials).size == 1
+
         spec_ds = freqanalysis(ds, tapsmofrq=1, keeptrials=False)
 
         # all channels are equal, trim off 0-frequency dip
@@ -199,6 +203,10 @@ class TestResampling:
             kwargs = {'resamplefs': self.fs * 0.43, 'order': 5000}
 
         rs = resampledata(self.adata, method='resample', **kwargs)
+        lenTrials = np.diff(rs.sampleinfo).squeeze()
+        # check for equal trials
+        assert np.unique(lenTrials).size == 1
+
         spec_rs = freqanalysis(rs, tapsmofrq=1, keeptrials=False)
 
         # all channels are equal,
@@ -235,6 +243,7 @@ class TestResampling:
                                                toi_max=self.time_span[1],
                                                min_len=3.5)
         for sd in sel_dicts:
+            print(sd)
             spec_rs = self.test_resampling(select=sd, resamplefs=self.fs / 2.1)
             # remove 3Hz window around the filter cut
             pow_rs = spec_rs.show(channel=0)[:-3].mean()


### PR DESCRIPTION
- there might still be some float precision edge cases lurking somewhere..

Changes to be committed:
	modified:   syncopy/preproc/compRoutines.py
	modified:   syncopy/tests/test_resampledata.py

Author Guidelines
-----------------
- [x] Is the change set **< 600 lines**?
- [x] Was the code checked for memory leaks/performance bottlenecks?
- [x] Is the code running locally **and** on the ESI cluster?
- [x] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do **parallel** loops have a set length and correct termination conditions?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [x] Code layout
  - [x] Is the code PEP8 compliant?
  - [x] Does the code adhere to agreed-upon naming conventions?
  - [x] Are keywords clearly named and easy to understand?
  - [x] No commented-out code?
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
