### PR TITLE
340 interface additional cf returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### NEW
+- Added additional .info entries for Granger analysis, indicating details about the computation
+- Added additional .info entries for FoooF results, e.i. Gaussian fit parameters
+
+### CHANGED
+- Maximal brute force regularization parameter for Granger increased to 1e-1
 
 ## [2022.08] - 2022-08-10
 

--- a/syncopy/nwanalysis/AV_compRoutines.py
+++ b/syncopy/nwanalysis/AV_compRoutines.py
@@ -134,7 +134,7 @@ class NormalizeCrossSpectra(ComputationalRoutine):
 
     computeFunction = staticmethod(normalize_csd_cF)
 
-    method = "" # there is no backend
+    method = ""  # there is no backend
     # 1st argument,the data, gets omitted
     valid_kws = list(signature(normalize_csd_cF).parameters.keys())[1:]
 
@@ -275,7 +275,7 @@ class NormalizeCrossCov(ComputationalRoutine):
 
     computeFunction = staticmethod(normalize_ccov_cF)
 
-    method = "" # there is no backend
+    method = ""   # there is no backend
     # 1st argument,the data, gets omitted
     valid_kws = list(signature(normalize_ccov_cF).parameters.keys())[1:]
 
@@ -429,14 +429,12 @@ def granger_cF(csd_av_dat,
     # calculate G-causality
     Granger = granger(CSDreg, H, Sigma)
 
+    # format is 'label--cast'
     metadata = {'converged--bool': np.array(conv),
                 'max rel. err--float': np.array(err),
                 'reg. factor--float': np.array(factor),
                 'initial cond. num--float': np.array(ini_cn)
                 }
-
-    for key, val in metadata.items():
-        print("cF", key, type(val))
 
     # reattach dummy time axis
     return Granger[None, ...], metadata
@@ -462,7 +460,7 @@ class GrangerCausality(ComputationalRoutine):
 
     computeFunction = staticmethod(granger_cF)
 
-    method = "" # there is no backend
+    method = ""   # there is no backend
     # 1st argument,the data, gets omitted
     valid_kws = list(signature(granger_cF).parameters.keys())[1:]
 
@@ -513,7 +511,7 @@ class GrangerCausality(ComputationalRoutine):
         out.channel_j = np.array(data.channel_j[chanSec_j])
         out.freq = data.freq
 
-        # digest metadata
+        # digest metadata and attach to .info property
         mdata = metadata_from_hdf5_file(out.filename)
 
         for key, value in mdata.items():

--- a/syncopy/nwanalysis/AV_compRoutines.py
+++ b/syncopy/nwanalysis/AV_compRoutines.py
@@ -396,8 +396,8 @@ def granger_cF(csd_av_dat,
     CSD = csd_av_dat[0]
 
     # auto-regularize to `cond_max` condition number
-    # maximal regularization factor is 1e-3
-    CSDreg, factor, ini_cn = regularize_csd(CSD, cond_max=cond_max, eps_max=1e-3)
+    # maximal regularization factor is 1e-1
+    CSDreg, factor, ini_cn = regularize_csd(CSD, cond_max=cond_max, eps_max=1e-1)
     # call Wilson
     H, Sigma, conv, err = wilson_sf(CSDreg, nIter=nIter, rtol=rtol)
 

--- a/syncopy/nwanalysis/AV_compRoutines.py
+++ b/syncopy/nwanalysis/AV_compRoutines.py
@@ -21,7 +21,7 @@ from .granger import granger
 
 # syncopy imports
 from syncopy.shared.const_def import spectralDTypes
-from syncopy.shared.computational_routine import ComputationalRoutine
+from syncopy.shared.computational_routine import ComputationalRoutine, propagate_properties
 from syncopy.shared.metadata import metadata_from_hdf5_file, cast_0array
 from syncopy.shared.kwarg_decorators import process_io
 from syncopy.shared.errors import (
@@ -157,32 +157,7 @@ class NormalizeCrossSpectra(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
-        # Some index gymnastics to get trial begin/end "samples"
-        if data.selection is not None:
-            chanSec_i = data.selection.channel_i
-            chanSec_j = data.selection.channel_j
-            trl = data.selection.trialdefinition
-            for row in range(trl.shape[0]):
-                trl[row, :2] = [row, row + 1]
-        else:
-            chanSec_i = slice(None)
-            chanSec_j = slice(None)
-            time = np.arange(len(data.trials))
-            time = time.reshape((time.size, 1))
-            trl = np.hstack((time, time + 1,
-                             np.zeros((len(data.trials), 1)),
-                             np.array(data.trialinfo)))
-
-        # Attach constructed trialdef-array (if even necessary)
-        if self.keeptrials:
-            out.trialdefinition = trl
-        else:
-            out.trialdefinition = np.array([[0, 1, 0]])
-
-        # Attach remaining meta-data
-        out.samplerate = data.samplerate
-        out.channel_i = np.array(data.channel_i[chanSec_i])
-        out.channel_j = np.array(data.channel_j[chanSec_j])
+        propagate_properties(data, out, self.keeptrials)
         out.freq = data.freq
 
 
@@ -483,32 +458,7 @@ class GrangerCausality(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
-        # Some index gymnastics to get trial begin/end "samples"
-        if data.selection is not None:
-            chanSec_i = data.selection.channel_i
-            chanSec_j = data.selection.channel_j
-            trl = data.selection.trialdefinition
-            for row in range(trl.shape[0]):
-                trl[row, :2] = [row, row + 1]
-        else:
-            chanSec_i = slice(None)
-            chanSec_j = slice(None)
-            time = np.arange(len(data.trials))
-            time = time.reshape((time.size, 1))
-            trl = np.hstack((time, time + 1,
-                             np.zeros((len(data.trials), 1)),
-                             np.array(data.trialinfo)))
-
-        # Attach constructed trialdef-array (if even necessary)
-        if self.keeptrials:
-            out.trialdefinition = trl
-        else:
-            out.trialdefinition = np.array([[0, 1, 0]])
-
-        # Attach remaining meta-data
-        out.samplerate = data.samplerate
-        out.channel_i = np.array(data.channel_i[chanSec_i])
-        out.channel_j = np.array(data.channel_j[chanSec_j])
+        propagate_properties(data, out, self.keeptrials)
         out.freq = data.freq
 
         # digest metadata and attach to .info property

--- a/syncopy/nwanalysis/ST_compRoutines.py
+++ b/syncopy/nwanalysis/ST_compRoutines.py
@@ -215,9 +215,9 @@ def cross_covariance_cF(trl_dat,
                         polyremoval=0,
                         timeAxis=0,
                         norm=False,
+                        fullOutput=False,
                         chunkShape=None,
-                        noCompute=False,
-                        fullOutput=False):
+                        noCompute=False):
 
     """
     Single trial covariance estimates between all channels

--- a/syncopy/nwanalysis/ST_compRoutines.py
+++ b/syncopy/nwanalysis/ST_compRoutines.py
@@ -197,22 +197,11 @@ class ST_CrossSpectra(ComputationalRoutine):
         # Some index gymnastics to get trial begin/end "samples"
         if data.selection is not None:
             chanSec = data.selection.channel
-            trl = data.selection.trialdefinition
-            for row in range(trl.shape[0]):
-                trl[row, :2] = [row, row + 1]
         else:
             chanSec = slice(None)
-            time = np.arange(len(data.trials))
-            time = time.reshape((time.size, 1))
-            trl = np.hstack((time, time + 1,
-                             np.zeros((len(data.trials), 1)),
-                             np.array(data.trialinfo)))
 
-        # Attach constructed trialdef-array (if even necessary)
-        if self.keeptrials:
-            out.trialdefinition = trl
-        else:
-            out.trialdefinition = np.array([[0, 1, 0]])
+        # there is always trial averaging
+        out.trialdefinition = np.array([[0, 1, 0]])
 
         # Attach remaining meta-data
         out.samplerate = data.samplerate

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -256,7 +256,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
 
         # Match desired frequencies as close as possible to
         # actually attainable freqs
-        # these are the frequencies attached to the SpectralData by the CR!
+        # these are the frequencies attached to the CrossSpectralData by the CR!
         if foi is not None:
             foi, _ = best_match(freqs, foi, squash_duplicates=True)
         elif foilim is not None:

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -307,14 +307,14 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
             lgl = f"one of {coh_outputs}"
             raise SPYValueError(lgl, varname="output", actual=output)
         log_dict['output'] = output
-        
+
         # final normalization after trial averaging
         av_compRoutine = NormalizeCrossSpectra(output=output)
 
     if method == 'granger':
         # after trial averaging
         # hardcoded numerical parameters
-        av_compRoutine = GrangerCausality(rtol=1e-8,
+        av_compRoutine = GrangerCausality(rtol=1e-6,
                                           nIter=100,
                                           cond_max=1e4
                                           )

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -73,12 +73,18 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
     "granger" : Spectral Granger-Geweke causality
         Computes linear causality estimates between
         all channel combinations. The intermediate cross-spectral
-        densities can be computed via multi-tapering.
+        densities can be computed also with multi-tapering.
 
         * **taper** : one of :data:`~syncopy.shared.const_def.availableTapers`
         * **tapsmofrq** : spectral smoothing box for slepian tapers (in Hz)
         * **nTaper** : (optional, not recommended) number of slepian tapers
         * **pad**: either pad to an absolute length in seconds or set to `'nextpow2'`
+
+        After the computation, information about the convergence and potential
+        regularization of the cross-spectral densities can be obtained
+        by inspecting the ``.info`` property of the resulting :class:~`syncopy.CrossSpectralData`
+        object. Keys of that info-dict are:
+            {'converged', 'max rel. err', 'reg. factor', 'initial cond. num'}
 
     Parameters
     ----------

--- a/syncopy/nwanalysis/csd.py
+++ b/syncopy/nwanalysis/csd.py
@@ -20,8 +20,7 @@ def csd(trl_dat,
         taper="hann",
         taper_opt=None,
         demean_taper=False,
-        norm=False,
-        fullOutput=False):
+        norm=False):
 
     """
     Single trial Fourier cross spectral estimates between all channels
@@ -69,9 +68,6 @@ def csd(trl_dat,
         Set to `True` to normalize for a single-trial coherence measure.
         Only meaningful in a multi-taper (``taper = "dpss"``) setup and if no
         additional (trial-)averaging is performed afterwards.
-    fullOutput : bool
-        For backend testing or stand-alone applications, set to `True`
-        to return also the `freqs` array.
 
     Returns
     -------
@@ -80,7 +76,7 @@ def csd(trl_dat,
         `K` corresponds to number of input channels.
 
     freqs : (nFreq,) :class:`numpy.ndarray`
-        The Fourier frequencies if ``fullOutput = True``
+        The Fourier frequencies
 
     See also
     --------
@@ -115,10 +111,7 @@ def csd(trl_dat,
         Ciijj = np.sqrt(diag[:, :, None] * diag[:, None, :]).T
         CS_ij = CS_ij / Ciijj
 
-    if fullOutput:
-        return CS_ij.transpose(2, 0, 1), freqs
-    else:
-        return CS_ij.transpose(2, 0, 1)
+    return CS_ij.transpose(2, 0, 1), freqs
 
 
 def normalize_csd(csd_av_dat,

--- a/syncopy/nwanalysis/granger.py
+++ b/syncopy/nwanalysis/granger.py
@@ -51,7 +51,7 @@ def granger(CSD, Hfunc, Sigma):
 
     nChannels = CSD.shape[1]
     auto_spectra = CSD.transpose(1, 2, 0).diagonal()
-    auto_spectra = np.abs(auto_spectra) # auto-spectra are real
+    auto_spectra = np.abs(auto_spectra)  # auto-spectra are real
 
     # we need the stacked auto-spectra of the form (nChannel=3):
     #           S_11 S_22 S_33

--- a/syncopy/preproc/compRoutines.py
+++ b/syncopy/preproc/compRoutines.py
@@ -10,7 +10,7 @@ import scipy.signal as sci
 from inspect import signature
 
 # syncopy imports
-from syncopy.shared.computational_routine import ComputationalRoutine, propagate_metadata
+from syncopy.shared.computational_routine import ComputationalRoutine, propagate_properties
 from syncopy.shared.const_def import spectralConversions, spectralDTypes
 from syncopy.shared.kwarg_decorators import process_io
 
@@ -155,7 +155,7 @@ class SincFiltering(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
-        propagate_metadata(data, out)
+        propagate_properties(data, out)
 
 
 @process_io
@@ -278,7 +278,7 @@ class ButFiltering(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
-        propagate_metadata(data, out)
+        propagate_properties(data, out)
 
 
 @process_io
@@ -340,7 +340,7 @@ class Rectify(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
-        propagate_metadata(data, out)
+        propagate_properties(data, out)
 
 
 @process_io
@@ -812,7 +812,7 @@ class Standardize(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
-        propagate_metadata(data, out)
+        propagate_properties(data, out)
 
 
 def _resampling_trl_definition(orig_trl, factor):

--- a/syncopy/preproc/compRoutines.py
+++ b/syncopy/preproc/compRoutines.py
@@ -418,7 +418,7 @@ class Hilbert(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
-        propagate_metadata(data, out)
+        propagate_properties(data, out)
 
 
 @process_io
@@ -721,7 +721,7 @@ class Detrending(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
-        propagate_metadata(data, out)
+        propagate_properties(data, out)
 
 
 @process_io

--- a/syncopy/shared/metadata.py
+++ b/syncopy/shared/metadata.py
@@ -1,4 +1,4 @@
-#  Function for handling additional return values from backend functions.
+#  Function for handling additional return values from compute functions
 
 import h5py
 import numpy as np
@@ -260,4 +260,5 @@ def cast_0array(rule, arr):
         act = f"{arr.ndim}-dim array"
         raise SPYValueError(lgl, "arr", act)
 
+    # return cast directly
     return rules[rule](arr)

--- a/syncopy/shared/metadata.py
+++ b/syncopy/shared/metadata.py
@@ -242,7 +242,7 @@ def cast_0array(rule, arr):
     """
     Helper routine to "unpack" hdf5 0-dim attribute arrays,
     as even though they are effectively scalar,
-    they can't be directly serialized.
+    they can't be directly serialized to go into .info
     """
 
     rules = {'float': lambda x: float(x),

--- a/syncopy/shared/metadata.py
+++ b/syncopy/shared/metadata.py
@@ -6,7 +6,6 @@ import numpy as np
 from syncopy.shared.errors import (SPYTypeError, SPYValueError, SPYWarning)
 
 
-
 def metadata_from_hdf5_file(h5py_filename, delete_afterwards=True):
     """
     Extract metadata from h5py file.
@@ -234,5 +233,31 @@ def extract_md_group(md):
     """
     metadata = dict()
     for k, v in md.attrs.items():
-        metadata[k] = v.copy() # copy the numpy array
+        metadata[k] = v.copy()  # copy the numpy array
     return metadata
+
+
+def cast_0array(rule, arr):
+
+    """
+    Helper routine to "unpack" hdf5 0-dim attribute arrays,
+    as even though they are effectively scalar,
+    they can't be directly serialized.
+    """
+
+    rules = {'float': lambda x: float(x),
+             'int': lambda x: int(x),
+             'bool': lambda x: bool(x),
+             'str': lambda x: str(x)
+             }
+
+    if rule not in rules:
+        lgl = f"one of {rules.keys()}"
+        raise SPYValueError(lgl, "rule", rule)
+
+    if arr.ndim != 0:
+        lgl = "0-dim numpy array"
+        act = f"{arr.ndim}-dim array"
+        raise SPYValueError(lgl, "arr", act)
+
+    return rules[rule](arr)

--- a/syncopy/tests/backend/test_conn.py
+++ b/syncopy/tests/backend/test_conn.py
@@ -205,7 +205,7 @@ def test_wilson():
 
     # --- factorize CSD with Wilson's algorithm ---
 
-    H, Sigma, conv = wilson_sf(CSDav, rtol=1e-6)
+    H, Sigma, conv, err = wilson_sf(CSDav, rtol=1e-6)
     # converged - \Psi \Psi^* \approx CSD,
     # with relative error <= rtol?
     assert conv
@@ -289,7 +289,7 @@ def test_granger():
     CSDav /= nTrials
     # with only 2 channels this CSD is well conditioned
     assert np.linalg.cond(CSDav).max() < 1e2
-    H, Sigma, conv = wilson_sf(CSDav, direct_inversion=True)
+    H, Sigma, conv, err = wilson_sf(CSDav, direct_inversion=True)
 
     G = granger(CSDav, H, Sigma)
     assert G.shape == CSDav.shape
@@ -311,7 +311,7 @@ def test_granger():
     assert G[freq_idx, 1, 0] > 0.7
 
     # repeat test with least-square solution
-    H, Sigma, conv = wilson_sf(CSDav, direct_inversion=False)
+    H, Sigma, conv, err = wilson_sf(CSDav, direct_inversion=False)
     G2 = granger(CSDav, H, Sigma)
 
     # check low to no causality for 1->2

--- a/syncopy/tests/backend/test_conn.py
+++ b/syncopy/tests/backend/test_conn.py
@@ -48,8 +48,7 @@ def test_coherence():
         # process every trial individually
         CSD, freqs = csd.csd(trl_dat, fs,
                              taper='hann',
-                             norm=False, # this is important!
-                             fullOutput=True)
+                             norm=False)  # this is important!
 
         assert avCSD.shape == CSD.shape
         avCSD += CSD
@@ -69,7 +68,7 @@ def test_coherence():
     fig, ax = ppl.subplots(figsize=(6, 4), num=None)
     ax.set_xlabel('frequency (Hz)')
     ax.set_ylabel('coherence')
-    ax.set_ylim((-.02,1.05))
+    ax.set_ylim((-.02, 1.05))
     ax.set_title(f'{nTrials} trials averaged coherence,  SNR=1')
 
     ax.plot(freqs, coh, lw=1.5, alpha=0.8, c='cornflowerblue')
@@ -112,25 +111,24 @@ def test_csd():
     data = np.array(data).T
     data = np.array(data) + np.random.randn(nSamples, len(phase_shifts))
 
-    bw = 8 #Hz
+    bw = 8  # Hz
     NW = nSamples * bw / (2 * fs)
-    Kmax = int(2 * NW - 1) # multiple tapers for single trial coherence
+    Kmax = int(2 * NW - 1)   # multiple tapers for single trial coherence
     CSD, freqs = csd.csd(data, fs,
                          taper='dpss',
-                         taper_opt={'Kmax' : Kmax, 'NW' : NW},
-                         norm=True,
-                         fullOutput=True)
+                         taper_opt={'Kmax': Kmax, 'NW': NW},
+                         norm=True)
 
-    # output has shape (1, nFreq, nChannels, nChannels)
+    # output has shape (nFreq, nChannels, nChannels)
     assert CSD.shape == (len(freqs), data.shape[1], data.shape[1])
 
     # single trial coherence between channel 0 and 1
     coh = np.abs(CSD[:, 0, 1])
 
-    fig, ax = ppl.subplots(figsize=(6,4), num=None)
+    fig, ax = ppl.subplots(figsize=(6, 4), num=None)
     ax.set_xlabel('frequency (Hz)')
     ax.set_ylabel('coherence')
-    ax.set_ylim((-.02,1.05))
+    ax.set_ylim((-.02, 1.05))
     ax.set_title(f'MTM coherence, {Kmax} tapers, SNR=1')
 
     ax.plot(freqs, coh, lw=1.5, alpha=0.8, c='cornflowerblue')
@@ -197,8 +195,8 @@ def test_wilson():
         # --- get the (single trial) CSD ---
 
         CSD, freqs = csd.csd(sol, fs,
-                             norm=False,
-                             fullOutput=True)
+                             norm=False)
+
         CSDav += CSD
 
     CSDav /= nTrials
@@ -236,15 +234,13 @@ def test_regularization():
         A = np.random.randn(50)
         CSD += np.outer(A, A)
 
-    # get CSD condition number, which is way too large!
-    CN = np.linalg.cond(CSD).max()
-    print(CN)
-    cmax = 1e6
-    assert CN > cmax
-
     # --- regularize CSD ---
 
-    CSDreg, fac = regularize_csd(CSD, cond_max=cmax, nSteps=25)
+    cmax = 1e4
+    CSDreg, fac, iniCN = regularize_csd(CSD, cond_max=cmax, nSteps=25)
+    # get initial CSD condition number, which is way too large!
+    print(iniCN)
+    assert iniCN > cmax
 
     CNreg = np.linalg.cond(CSDreg).max()
     assert CNreg < 1e6
@@ -281,7 +277,6 @@ def test_granger():
         CSD, freqs = csd.csd(sol, fs,
                              taper='dpss',
                              taper_opt={'Kmax': Kmax, 'NW': NW},
-                             fullOutput=True,
                              demean_taper=True)
 
         CSDav += CSD

--- a/syncopy/tests/backend/test_conn.py
+++ b/syncopy/tests/backend/test_conn.py
@@ -228,24 +228,32 @@ def test_wilson():
 
 def test_regularization():
 
-    # dyadic product of random matrices has rank 1
-    CSD = np.zeros((50, 50))
-    for _ in range(40):
-        A = np.random.randn(50)
+    """
+    The dyadic product of single random matrices has rank 1
+    and condition number --> np.inf.
+    By averaging "many trials" we interestingly "fill the space" and
+    one can achieve full rank for white noise.
+    However here purposefully we ill-condition to test the regularization,
+    """
+    nChannels = 20
+    nTrials = 10
+    CSD = np.zeros((nChannels, nChannels))
+    for _ in range(nTrials):
+        A = np.random.randn(nChannels)
         CSD += np.outer(A, A)
 
     # --- regularize CSD ---
 
     cmax = 1e4
-    CSDreg, fac, iniCN = regularize_csd(CSD, cond_max=cmax, nSteps=25)
-    # get initial CSD condition number, which is way too large!
-    print(iniCN)
-    assert iniCN > cmax
+    eps_max = 1e-1
+    CSDreg, fac, iniCN = regularize_csd(CSD, cond_max=cmax, eps_max=eps_max)
+    # check initial CSD condition number, which is way too large!
+    assert iniCN > cmax, f"intial condition number is {iniCN}"
 
     CNreg = np.linalg.cond(CSDreg).max()
-    assert CNreg < 1e6
+    assert CNreg < cmax, f"regularized condition number is {CNreg}"
     # check that 'small' regularization factor is enough
-    assert fac < 1e-3
+    assert fac < eps_max
 
 
 def test_granger():

--- a/syncopy/tests/backend/test_fooofspy.py
+++ b/syncopy/tests/backend/test_fooofspy.py
@@ -23,7 +23,7 @@ def _power_spectrum(freq_range=[3, 40],
     # the Gaussians: Mean (Center Frequency), height (Power), and standard deviation (Bandwidth).
     periodic_params = [[10, 0.2, 1.25], [30, 0.15, 2]]
 
-    noise_level = 0.005
+    noise_level = 0.001
     freqs, powers = gen_power_spectrum(freq_range, aperiodic_params,
                                        periodic_params, nlv=noise_level, freq_res=freq_res)
     return freqs, powers

--- a/syncopy/tests/backend/test_fooofspy.py
+++ b/syncopy/tests/backend/test_fooofspy.py
@@ -56,7 +56,7 @@ class TestSpfooof():
 
     def test_output_fooof_single_channel(self, freqs=freqs, powers=powers):
         """
-        Tests spfooof with output 'fooof' and a single input signal/channel.
+        Tests spfooof with output 'fooof' and a single input spectrum/channel.
         This will return the full, fooofed spectrum.
         """
         spectra, details = fooofspy(powers, freqs, out_type='fooof', fooof_opt={'peak_width_limits': (1.0, 12.0)})

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -34,8 +34,8 @@ skip_low_mem = pytest.mark.skipif(availMem < minRAM * 1024**3, reason=f"less tha
 
 class TestGranger:
 
-    nTrials = 100
-    nChannels = 5
+    nTrials = 150
+    nChannels = 4
     nSamples = 1000
     fs = 200
 
@@ -45,8 +45,7 @@ class TestGranger:
     # the adjacency matrix
     # encodes coupling strength directly
     AdjMat = np.zeros((nChannels, nChannels))
-    AdjMat[0, 4] = 0.15
-    AdjMat[3, 4] = 0.15
+    AdjMat[3, 1] = 0.15
     AdjMat[3, 2] = 0.25
     AdjMat[1, 0] = 0.25
 
@@ -66,7 +65,7 @@ class TestGranger:
     def test_gr_solution(self, **kwargs):
 
         Gcaus = cafunc(self.data, method='granger',
-                       tapsmofrq=3, foi=None, **kwargs)
+                       tapsmofrq=1, foi=None, **kwargs)
 
         # check all channel combinations with coupling
         for i, j in zip(*self.cpl_idx):
@@ -86,6 +85,13 @@ class TestGranger:
             if len(kwargs) == 0:
                 plot_Granger(Gcaus, i, j)
                 ppl.legend()
+
+        # check .info for default test
+        if len(kwargs) == 0:
+            assert Gcaus.info['converged']
+            assert Gcaus.info['max rel. err'] < 1e-5
+            assert Gcaus.info['reg. factor'] == 0
+            assert Gcaus.info['initial cond. num'] > 10
 
     def test_gr_selections(self):
 

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -227,7 +227,6 @@ class TestCoherence:
                                                 *self.time_span)
 
         for sel_dct in selections:
-
             result = cafunc(self.data, method='coh', select=sel_dct)
 
             # check here just for finiteness and positivity

--- a/syncopy/tests/test_specest.py
+++ b/syncopy/tests/test_specest.py
@@ -1404,3 +1404,4 @@ class TestSuperlet():
 
 if __name__ == '__main__':
     T1 = TestMTMConvol()
+    T2 = TestMTMFFT()


### PR DESCRIPTION
## Make use of additional cF returns

- Granger now returns 4 additional metadata entries stored in `.info` documenting the factorization
- equality of frequency axis for mtmfft and csd get checked via hashes
- Further refactored `process_metadata` to reduce copied code and have one place where the properties get attached from input to output (`propagate_properties`)

closes #148
closes #340 

Author Guidelines
-----------------
- [x] Is the change set **< 600 lines**?
- [x] Was the code checked for memory leaks/performance bottlenecks?
- [x] Is the code running locally **and** on the ESI cluster?
- [x] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do **parallel** loops have a set length and correct termination conditions?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [x] Code layout
  - [x] Is the code PEP8 compliant?
  - [x] Does the code adhere to agreed-upon naming conventions?
  - [x] Are keywords clearly named and easy to understand?
  - [x] No commented-out code?
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
