### PR TITLE
Psth tests

### DIFF
--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -1353,16 +1353,19 @@ class Selector():
 
     @property
     def trials(self):
-        """Returns a single trial array respecting existing selections"""
-        return self._trl_indexer
+        """
+        Returns an Indexer indexing single trial arrays respecting the selection
+        Indices are RELATIVE with respect to existing trial selections:
 
-    @trials.setter
-    def trials(self, dataselect):
+        >>> selection.trials[2]
+
+        indexes the 3rd trial of `selection.trial_ids`
+
+        Selections must be "simple": ordered and without repetitions
         """
-        Gets only set once during Selector init and creates
-        an Indexer akin to BaseData.trials
-        """
-        pass
+
+        return Indexer(map(self._get_trial, self.trial_ids),
+                       len(self.trial_ids)) if self.trial_ids is not None else None
 
     def create_get_trial(self, data):
         """ Closure to allow emulation of BaseData._get_trial"""
@@ -1373,7 +1376,6 @@ class Selector():
                 lgl = "a trial part of the selection"
                 act = trl_id
                 raise SPYValueError(lgl, "Selector.trials", act)
-
             # extract the selection respecting FauxTrial idx tuple
             # which has length len(data.dimord) or 2 if `data` is a DiscreteData instance
             trl_idx = data._preview_trial(trl_id).idx

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -592,8 +592,20 @@ class BaseData(ABC):
         raise SPYError("Cannot set sampleinfo. Use `BaseData._trialdefinition` instead.")
 
     @property
+    def trialintervals(self):
+        """nTrials x 2 :class:`numpy.ndarray` of [start, end] times in seconds """
+        if self._trialdefinition is not None and self._samplerate is not None:
+            # trial lengths in samples
+            start_end = self.sampleinfo - self.sampleinfo[:, 0][:, None]
+            # add offset and convert to seconds
+            start_end = (start_end + self._t0[:, None]) / self._samplerate
+            return start_end
+        else:
+            return None
+
+    @property
     def _t0(self):
-        """ These are the trigger offsets """
+        """ These are the (trigger) offsets """
         if self._trialdefinition is not None:
             return self._trialdefinition[:, 2]
         else:
@@ -1503,6 +1515,18 @@ class Selector():
     @sampleinfo.setter
     def sampleinfo(self, sinfo):
         raise SPYError("Cannot set sampleinfo. Use `Selector.trialdefinition` instead.")
+
+    @property
+    def trialintervals(self):
+        """nTrials x 2 :class:`numpy.ndarray` of [start, end] times in seconds """
+        if self._trialdefinition is not None and self._samplerate is not None:
+            # trial lengths in samples
+            start_end = self.sampleinfo - self.sampleinfo[:, 0][:, None]
+            # add offset and convert to seconds
+            start_end = (start_end + self.trialdefinition[:, 2][:, None]) / self._samplerate
+            return start_end
+        else:
+            return None
 
     @property
     def timepoints(self):

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -1382,15 +1382,15 @@ class Selector():
 
             # now massage/validate it such that we can use it to
             # directly index the hdf5 dataset
-            # tuple elements can only be lists or slices, see concrete
+            # tuple elements can only be lists or ordered slices, see concrete
             # `_preview_trial` implementations which generate those idx tuples
             # maybe TODO: allow fancy indexing like in the CR
             for i, dim_idx in enumerate(trl_idx):
                 if isinstance(dim_idx, list):
                     # no fancy indexing, no repetitions
                     if len(set(dim_idx)) != len(dim_idx):
-                        lgl = "Simple selections w/o repetitions"
-                        act = f"Fancy selection with repetitions for selector {data.dimord[i]}"
+                        lgl = "simple selections w/o repetitions"
+                        act = f"fancy selection with repetitions for selector {data.dimord[i]}"
                         raise SPYValueError(lgl, "Selector.trials", act)
 
                     # DiscreteData selections inherently re-order the sample dim. idx
@@ -1399,13 +1399,8 @@ class Selector():
                         # sorts in place!
                         dim_idx.sort()
                     elif np.any(np.diff(dim_idx) < 0):
-                        lgl = "Simple selection in ascending order"
-                        act = f"Fancy non-ordered selection of selector {data.dimord[i]}"
-                        raise SPYValueError(lgl, "Selector.trials", act)
-                elif isinstance(dim_idx, slice):
-                    if dim_idx.step is not None and dim_idx.step < 0:
-                        lgl = "Simple selection in ascending order"
-                        act = f"Descending selection of selector {data.dimord[i]}"
+                        lgl = "simple selection in ascending order"
+                        act = f"fancy non-ordered selection of selector {data.dimord[i]}"
                         raise SPYValueError(lgl, "Selector.trials", act)
             # if we landed here all is good and we take
             # a leap of faith into the hdf5 dataset

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -1159,7 +1159,7 @@ class Selector():
         to be used as (fancy) indexing tuples. Note that the properties `time`,
         `unit` and `eventid` are **by-trial** selections, i.e., list of lists
         and/or slices encoding per-trial sample-indices, e.g., ``selection.time[0]``
-        is intended to be used with ``data.trials[selection.trials[0]]``.
+        is intended to be used with ``data.trials[selection.trial_ids[0]]``.
         Addditional class attributes of note:
 
         * `_useFancy` : bool
@@ -1296,7 +1296,7 @@ class Selector():
 
         # We first need to know which trials are of interest here (assuming
         # that any valid input object *must* have a `trials` attribute)
-        self.trials = (data, select)
+        self.trial_ids = (data, select)
 
         # Now set any possible selection attribute (depending on type of `data`)
         # Note: `trialdefinition` is set *after* harmonizing indexing selections
@@ -1313,12 +1313,12 @@ class Selector():
         self.select = select
 
     @property
-    def trials(self):
+    def trial_ids(self):
         """Index list of selected trials"""
-        return self._trials
+        return self._trial_ids
 
-    @trials.setter
-    def trials(self, dataselect):
+    @trial_ids.setter
+    def trial_ids(self, dataselect):
         data, select = dataselect
         trlList = list(range(len(data.trials)))
         trials = select.get("trials", None)

--- a/syncopy/datatype/continuous_data.py
+++ b/syncopy/datatype/continuous_data.py
@@ -181,28 +181,6 @@ class ContinuousData(BaseData, ABC):
             return [(np.arange(0, stop - start) + self._t0[tk]) / self.samplerate \
                     for tk, (start, stop) in enumerate(self.sampleinfo)]
 
-    # # Helper function that reads a single trial into memory
-    # @staticmethod
-    # def _copy_trial(trialno, filename, dimord, sampleinfo):
-    #     """
-    #     # FIXME: currently unused - check back to see if we need this functionality
-    #     """
-    #     idx = [slice(None)] * len(dimord)
-    #     idx[dimord.index("time")] = slice(int(sampleinfo[trialno, 0]), int(sampleinfo[trialno, 1]))
-    #     idx = tuple(idx)
-    #     try:
-    #         with h5py.File(filename, mode="r") as h5f:
-    #             h5keys = list(h5f.keys())
-    #             cnt = [h5keys.count(dclass) for dclass in spy.datatype.__all__
-    #                    if not inspect.isfunction(getattr(spy.datatype, dclass))]
-    #             if len(h5keys) == 1:
-    #                 arr = h5f[h5keys[0]][idx]
-    #             else:
-    #                 arr = h5f[spy.datatype.__all__[cnt.index(1)]][idx]
-    #     except:
-    #         raise SPYIOError(filename)
-    #     return arr
-
     # Helper function that grabs a single trial
     def _get_trial(self, trialno):
         idx = [slice(None)] * len(self.dimord)

--- a/syncopy/datatype/continuous_data.py
+++ b/syncopy/datatype/continuous_data.py
@@ -230,7 +230,7 @@ class ContinuousData(BaseData, ABC):
         if self.selection is not None:
 
             # time-selection is most delicate due to trial-offset
-            tsel = self.selection.time[self.selection.trials.index(trialno)]
+            tsel = self.selection.time[self.selection.trial_ids.index(trialno)]
             if isinstance(tsel, slice):
                 if tsel.start is not None:
                     tstart = tsel.start

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -222,7 +222,7 @@ class DiscreteData(BaseData, ABC):
         nCol = len(self.dimord)
         idx = [trialIdx.tolist(), slice(0, nCol)]
         if self.selection is not None: # selections are harmonized, just take `.time`
-            idx[0] = trialIdx[self.selection.time[self.selection.trials.index(trialno)]].tolist()
+            idx[0] = trialIdx[self.selection.time[self.selection.trial_ids.index(trialno)]].tolist()
         shp = [len(idx[0]), nCol]
 
         return FauxTrial(shp, tuple(idx), self.data.dtype, self.dimord)

--- a/syncopy/datatype/methods/arithmetic.py
+++ b/syncopy/datatype/methods/arithmetic.py
@@ -140,7 +140,7 @@ def _parse_input(obj1, obj2, operator):
     if baseObj.selection is None:
         baseObj.selectdata(inplace=True)
         baseObj.selection._cleanup = True
-    baseTrialList = baseObj.selection.trials
+    baseTrialList = baseObj.selection.trial_ids
 
     # Use the `_preview_trial` functionality of Syncopy objects to get each trial's
     # shape and dtype (existing selections are taken care of automatically)
@@ -218,7 +218,7 @@ def _parse_input(obj1, obj2, operator):
             wrng = "Found existing in-place selection in operand. " +\
                 "Shapes and trial counts of base and operand objects have to match up!"
             SPYWarning(wrng, caller=operator)
-            opndTrialList = operand.selection.trials
+            opndTrialList = operand.selection.trial_ids
         else:
             opndTrialList = list(range(len(operand.trials)))
 

--- a/syncopy/datatype/methods/padding.py
+++ b/syncopy/datatype/methods/padding.py
@@ -297,7 +297,7 @@ def padding(data, padtype, pad="absolute", padlength=None, prepadlength=None,
     # quantities in tmp attributes (all prefixed by `'_pad'`)
     if spydata:
         if data.selection is not None:
-            trialList = data.selection.trials
+            trialList = data.selection.trial_ids
             data._pad_sinfo = np.zeros((len(trialList), 2))
             data._pad_t0 = np.zeros((len(trialList),))
             for tk, trlno in enumerate(trialList):

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -360,7 +360,7 @@ def _get_selection_size(data):
     """
     Local helper routine for computing the on-disk size of an active data-selection
     """
-    fauxTrials = [data._preview_trial(trlno) for trlno in data.selection.trials]
+    fauxTrials = [data._preview_trial(trlno) for trlno in data.selection.trial_ids]
     fauxSizes = [np.prod(ftrl.shape)*ftrl.dtype.itemsize for ftrl in fauxTrials]
     return sum(fauxSizes) / 1024**2
 

--- a/syncopy/datatype/methods/show.py
+++ b/syncopy/datatype/methods/show.py
@@ -163,7 +163,7 @@ def show(data, squeeze=True, **kwargs):
 
     # Use an object's `_preview_trial` method fetch required indexing tuples
     idxList = []
-    for trlno in data.selection.trials:
+    for trlno in data.selection.trial_ids:
         # each dim has an entry
         idxs = data._preview_trial(trlno).idx
 

--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -399,7 +399,7 @@ class ComputationalRoutine(ABC):
             sourceLayout.append(trial.idx)
             sourceShapes.append(trial.shape)
 
-        # Construct dimensional layout of output
+        # Construct dimensional layout of output and append remaining trials to input layout
         stacking = targetLayout[0][stackingDim].stop
         for tk in range(1, self.numTrials):
             trial = trials[tk]
@@ -445,7 +445,7 @@ class ComputationalRoutine(ABC):
         # In this case `sourceLayout` uses ABSOLUTE indices (indices wrt to size
         # of ENTIRE DATASET) that are SORTED W/O REPS to extract a NumPy array
         # of appropriate size from HDF5.
-        # Then `sourceLayout` uses RELATIVE indices (indices wrt to size of CURRENT
+        # Then `sourceSelectors` uses RELATIVE indices (indices wrt to size of CURRENT
         # TRIAL) that can be UNSORTED W/REPS to actually perform the requested
         # selection on the NumPy array extracted w/`sourceLayout`.
         for grd in sourceLayout:

--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -140,7 +140,7 @@ class ComputationalRoutine(ABC):
         # numerical type of output dataset
         self.dtype = None
 
-        # list of trial numbers to process (either `data.trials` or `data.selection.trials`)
+        # list of trial numbers to process (either list(range(len(`data.trials`))) or `data.selection.trial_ids`)
         self.trialList = None
 
         # number of trials to process (shortcut for `len(self.trialList)`)
@@ -268,7 +268,7 @@ class ComputationalRoutine(ABC):
         # Determine if data-selection was provided; if so, extract trials and check
         # whether selection requires fancy array indexing
         if data.selection is not None:
-            self.trialList = data.selection.trials
+            self.trialList = data.selection.trial_ids
             self.useFancyIdx = data.selection._useFancy
         else:
             self.trialList = list(range(len(data.trials)))
@@ -610,7 +610,7 @@ class ComputationalRoutine(ABC):
             # parallel case, `trl_dat` is a dictionary!
 
             # Use the trial IDs from the selection, so we have absolute trial indices.
-            trial_ids = data.selection.trials if data.selection is not None else range(self.numTrials)
+            trial_ids = data.selection.trial_ids if data.selection is not None else range(self.numTrials)
 
             # Use trial_ids and chunk_ids to turn into a unique index.
             if self.numBlocksPerTrial == 1:  # The simple case: 1 call per trial. We add a chunk id (the trailing `_0` to be consistent with
@@ -924,7 +924,7 @@ class ComputationalRoutine(ABC):
                     # (use an explicit `shape` assignment here to avoid copies)
                     res.shape = self.targetShapes[nblock]
 
-                    trial_idx = data.selection.trials[nblock] if data.selection is not None else nblock
+                    trial_idx = data.selection.trial_ids[nblock] if data.selection is not None else nblock
 
                     h5_add_metadata(h5fout, details, unique_key_suffix=trial_idx)
 

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -356,7 +356,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
             lgl = "no `toi` specification due to active in-place time-selection in input dataset"
             raise SPYValueError(legal=lgl, varname="toi", actual=toi)
         sinfo = data.selection.trialdefinition[:, :2]
-        trialList = data.selection.trials
+        trialList = data.selection.trial_ids
     else:
         trialList = list(range(len(data.trials)))
         sinfo = data.sampleinfo

--- a/syncopy/spikes/compRoutines.py
+++ b/syncopy/spikes/compRoutines.py
@@ -23,6 +23,7 @@ def psth_cF(trl_dat,
             trl_end,
             chan_unit_combs=None,
             tbins=None,
+            output='rate',
             samplerate=1000,
             noCompute=False,
             chunkShape=None):
@@ -53,7 +54,7 @@ def psth_cF(trl_dat,
         An array of monotonically increasing PSTH bin edges
         in seconds including the rightmost edge
         Defaults with `None` to the Rice rule
-
+    output : {'rate', 'spikecount', 'proportion'}, optional
     noCompute : bool
         Preprocessing flag. If `True`, do not perform actual calculation but
         instead return expected shape and :class:`numpy.dtype` of output
@@ -98,7 +99,7 @@ def psth_cF(trl_dat,
     # call backend method
     counts, bins = psth(trl_dat, trl_start, onset, trl_end,
                         chan_unit_combs=chan_unit_combs,
-                        tbins=tbins, samplerate=samplerate)
+                        tbins=tbins, samplerate=samplerate, output=output)
 
     return counts
 

--- a/syncopy/spikes/compRoutines.py
+++ b/syncopy/spikes/compRoutines.py
@@ -129,7 +129,7 @@ class PSTH(ComputationalRoutine):
         # compute new time axis / samplerate
         bin_midpoints = stride_tricks.sliding_window_view(tbins, (2,)).mean(axis=1)
         srate = 1 / np.diff(bin_midpoints).mean()
-
+        print(bin_midpoints)
         # each trial has the same length
         # for "timelocked" (same bins) psth data
         trl_len = len(tbins) - 1
@@ -144,7 +144,9 @@ class PSTH(ComputationalRoutine):
         sample_idx = np.arange(0, nTrials * trl_len + 1, trl_len)
         trl[:, :2] = stride_tricks.sliding_window_view(sample_idx, (2,))
         # negative relative time is pre-stimulus!
-        offsets = np.rint(tbins[0] * srate)
+        # note that bin edges are set on the original (high-res) time axis
+        # we can only approximate atm with the new 1/srate time steps
+        offsets = np.rint(bin_midpoints[0] * srate)
         trl[:, 2] = offsets
 
         # Attach meta-data

--- a/syncopy/spikes/compRoutines.py
+++ b/syncopy/spikes/compRoutines.py
@@ -129,7 +129,7 @@ class PSTH(ComputationalRoutine):
         # compute new time axis / samplerate
         bin_midpoints = stride_tricks.sliding_window_view(tbins, (2,)).mean(axis=1)
         srate = 1 / np.diff(bin_midpoints).mean()
-        print(bin_midpoints)
+
         # each trial has the same length
         # for "timelocked" (same bins) psth data
         trl_len = len(tbins) - 1
@@ -144,7 +144,7 @@ class PSTH(ComputationalRoutine):
         sample_idx = np.arange(0, nTrials * trl_len + 1, trl_len)
         trl[:, :2] = stride_tricks.sliding_window_view(sample_idx, (2,))
         # negative relative time is pre-stimulus!
-        # note that bin edges are set on the original (high-res) time axis
+        # note that bin edges are set on the input data (high-res) time axis
         # we can only approximate atm with the new 1/srate time steps
         offsets = np.rint(bin_midpoints[0] * srate)
         trl[:, 2] = offsets
@@ -154,6 +154,10 @@ class PSTH(ComputationalRoutine):
             out.trialdefinition = trl
         else:
             out.trialdefinition = trl[[0], :]
+            # the ad-hoc averaging does not work well here
+            # so we rather delete the data to 'not keep the trials'
+            out.data = None
+            # TODO: add real average operator here
 
         out.samplerate = srate
         # join labels for final unitX_channelY channel labels

--- a/syncopy/spikes/compRoutines.py
+++ b/syncopy/spikes/compRoutines.py
@@ -154,12 +154,14 @@ class PSTH(ComputationalRoutine):
             out.trialdefinition = trl
         else:
             out.trialdefinition = trl[[0], :]
-            # the ad-hoc averaging does not work well here
-            # so we rather delete the data to 'not keep the trials'
-            out.data = None
-            # TODO: add real average operator here
 
         out.samplerate = srate
         # join labels for final unitX_channelY channel labels
         chan_str = "channel{}_unit{}"
         out.channel = [chan_str.format(c, u) for c, u in self.cfg['chan_unit_combs']]
+
+        if not self.keeptrials:
+            # the ad-hoc averaging does not work well here because of NaNs
+            # so we rather delete the data to 'not keep the trials'
+            out.data = None
+            # TODO: add real average operator here

--- a/syncopy/spikes/compRoutines.py
+++ b/syncopy/spikes/compRoutines.py
@@ -134,7 +134,7 @@ class PSTH(ComputationalRoutine):
         # for "timelocked" (same bins) psth data
         trl_len = len(tbins) - 1
         if data.selection is not None:
-            nTrials = len(data.selection.trials)
+            nTrials = len(data.selection.trial_ids)
         else:
             nTrials = len(data.trials)
 

--- a/syncopy/spikes/psth.py
+++ b/syncopy/spikes/psth.py
@@ -141,10 +141,13 @@ def psth(trl_dat,
     if output == 'rate':
         tbin_width = np.diff(tbins)[0]
         counts *= 1 / tbin_width
-    # normalize only along 1d time axis
+
+    # normalize only along time axis for 1d time-histograms
+    # `density=True` normalized the full 2d-histogram
     elif output == 'proportion':
         norm = np.nansum(counts, axis=0)[None, :]
-        print(norm)
+        # deal with potential 0's
+        norm[norm == 0] = 1
         counts /= norm
 
     return counts, bins

--- a/syncopy/spikes/psth.py
+++ b/syncopy/spikes/psth.py
@@ -129,8 +129,18 @@ def psth(trl_dat,
     trl_end_reltime = (trl_end - trl_start + onset) / samplerate
 
     # mask indices along the time bin axis
-    min_idx = np.argmin(tbins < trl_start_reltime)
-    max_idx = np.argmin(tbins <= trl_end_reltime)
+    # which are completely outside of latency window
+    # mask all
+    if np.all(tbins < trl_start_reltime):
+        min_idx = len(counts)
+    else:
+        min_idx = np.argmin(tbins < trl_start_reltime)
+    # mask all
+    if np.all(tbins > trl_end_reltime):
+        min_idx = len(counts)
+        max_idx = 0
+    else:
+        max_idx = np.argmin(tbins <= trl_end_reltime)
 
     if min_idx != 0:
         counts[:min_idx] = np.nan

--- a/syncopy/spikes/psth.py
+++ b/syncopy/spikes/psth.py
@@ -8,6 +8,7 @@ def psth(trl_dat,
          trl_end,
          chan_unit_combs=None,
          tbins=None,
+         output='rate',
          samplerate=1000):
 
     """
@@ -37,6 +38,11 @@ def psth(trl_dat,
         An array of monotonically increasing PSTH bin edges
         in seconds including the rightmost edge
         Defaults with `None` to the Rice rule
+    output : {'rate', 'spikecount', 'proportion'}, optional
+        Set to `'rate'` to convert the output to firing rates (spikes/sec),
+        'spikecount' to count the number spikes per trial or
+        'proportion' to normalize the area under the PSTH to 1
+        Defaults to `'rate'`
     samplerate : float
         Samplerate in Hz
 
@@ -94,6 +100,12 @@ def psth(trl_dat,
     # map into histogram time x channel dimensions
     map_unit_hist = {u: [np.any(map_cu(c, u)) for c in chan_vec] for u in unique_units}
 
+    # configure output
+    if output in ['rate', 'spikecount']:
+        density = False
+    elif output == 'proportion':
+        density = True
+
     for i, iunit in enumerate(unique_units):
         unit_idx = (units == iunit)
 
@@ -101,13 +113,13 @@ def psth(trl_dat,
             # over all channels, so this counts different units actually
             unit_counts = np.histogram2d(times[unit_idx],
                                          channels[unit_idx],
-                                         bins=bins)[0]
+                                         bins=bins, density=density)[0]
 
             # get indices to inject the results
             # at the right position
             cu_idx = map_unit[iunit]
 
-            # masks non-existent combinations in histogram
+            # de-selects non-existent combinations in histogram
             chan_hist_idx = map_unit_hist[iunit]
             counts[:, cu_idx] = unit_counts[:, chan_hist_idx].astype(np.float32)
 
@@ -116,14 +128,24 @@ def psth(trl_dat,
     trl_start_reltime = onset / samplerate
     trl_end_reltime = (trl_end - trl_start + onset) / samplerate
 
-    # indices along the time bin axis
-    min_idx = np.argmin(trl_start_reltime > tbins)
-    max_idx = np.argmin(trl_end_reltime > tbins)
+    # mask indices along the time bin axis
+    min_idx = np.argmin(tbins < trl_start_reltime)
+    max_idx = np.argmin(tbins <= trl_end_reltime)
 
     if min_idx != 0:
-        counts[:min_idx - 1] = np.nan
+        counts[:min_idx] = np.nan
     if max_idx != 0:
         counts[max_idx:] = np.nan
+
+    # normalize to counts per second
+    if output == 'rate':
+        tbin_width = np.diff(tbins)[0]
+        counts *= 1 / tbin_width
+    # normalize only along 1d time axis
+    elif output == 'proportion':
+        norm = np.nansum(counts, axis=0)[None, :]
+        print(norm)
+        counts /= norm
 
     return counts, bins
 

--- a/syncopy/spikes/spike_psth.py
+++ b/syncopy/spikes/spike_psth.py
@@ -98,7 +98,7 @@ def spike_psth(data,
         trl_def = data.selection.trialdefinition
         sinfo = data.selection.trialdefinition[:, :2]
         # why is this not directly data.selection.trials?!
-        trials = Indexer(map(data._get_trial, data.selection.trials),
+        trials = Indexer(map(data._get_trial, data.selection.trial_ids),
                          sinfo.shape[0])
         trl_ivl = data.selection.trialintervals
         # beginnings and ends of all (selected) trials in trigger-relative time
@@ -196,13 +196,13 @@ def spike_psth(data,
             # redefinition needed
             trl_def = data.selection.trialdefinition
             sinfo = data.selection.trialdefinition[:, :2]
-            trials = Indexer(map(data._get_trial, data.selection.trials),
+            trials = Indexer(map(data._get_trial, data.selection.trial_ids),
                              sinfo.shape[0])
             numDiscard = len(trl_idx) - len(fit_trl_idx)
         else:
             # match fitting trials with selected ones
-            fit_trl_idx = np.intersect1d(data.selection.trials, fit_trl_idx)
-            numDiscard = len(data.selection.trials) - len(fit_trl_idx)
+            fit_trl_idx = np.intersect1d(data.selection.trial_ids, fit_trl_idx)
+            numDiscard = len(data.selection.trial_ids) - len(fit_trl_idx)
 
             if fit_trl_idx.size == 0:
                 lgl = 'at least one trial covering the latency window'
@@ -216,7 +216,7 @@ def spike_psth(data,
             # now redefine local variables
             trl_def = data.selection.trialdefinition
             sinfo = data.selection.trialdefinition[:, :2]
-            trials = Indexer(map(data._get_trial, data.selection.trials),
+            trials = Indexer(map(data._get_trial, data.selection.trial_ids),
                              sinfo.shape[0])
         msg = f"Discarded {numDiscard} trials which did not fit into latency window"
         SPYInfo(msg)

--- a/syncopy/spikes/spike_psth.py
+++ b/syncopy/spikes/spike_psth.py
@@ -20,12 +20,13 @@ from syncopy.shared.kwarg_decorators import (
 from syncopy.shared.input_processors import check_passed_kwargs
 
 
-# method specific imports - they should go when
-# we have multiple returns
-from syncopy.spikes.psth import Rice_rule, sqrt_rule, get_chan_unit_combs
+# dev
+from syncopy.tests import synth_data as sd
+spd = sd.poisson_noise(10, nUnits=3, nChannels=10, nSpikes=10000, samplerate=10000)
 
 # Local imports
 from syncopy.spikes.compRoutines import PSTH
+from syncopy.spikes.psth import Rice_rule, sqrt_rule, get_chan_unit_combs
 
 available_binsizes = {'rice': Rice_rule, 'sqrt': sqrt_rule}
 available_outputs = ['rate', 'spikecount', 'proportion']
@@ -111,9 +112,12 @@ def spike_psth(data,
 
     # --- parse and digest `latency` (time window of analysis) ---
 
-    # beginnings and ends of all (selected) trials in relative time
-    beg_ends = sinfo + trl_def[:, 2][:, None]
-    beg_ends = (beg_ends - sinfo[:, 0][:, None]) / data.samplerate
+    # beginnings and ends of all (selected) trials in trigger-relative time
+
+    # length in samples
+    beg_ends = sinfo - sinfo[:, 0][:, None]
+    # add offset and transform to seconds
+    beg_ends = (beg_ends + trl_def[:, 2][:, None]) / data.samplerate
 
     trl_starts = beg_ends[:, 0]
     trl_ends = beg_ends[:, 1]
@@ -161,6 +165,8 @@ def spike_psth(data,
     if not vartriallen:
         # trial idx for whole dataset
         trl_idx = np.arange(len(data.trials))
+        print(trl_starts)
+        print(trl_ends)
         bmask = (trl_starts <= window[0]) & (trl_ends >= window[1])
 
         # trials which fit completely into window

--- a/syncopy/spikes/spike_psth.py
+++ b/syncopy/spikes/spike_psth.py
@@ -56,7 +56,8 @@ def spike_psth(data,
     output : {'rate', 'spikecount', 'proportion'}, optional
         Set to `'rate'` to convert the output to firing rates (spikes/sec),
         'spikecount' to count the number spikes per trial or
-        'proportion' to normalize the area under the PSTH to 1.
+        'proportion' to normalize the area under the PSTH to 1
+        Defaults to `'rate'`
     vartriallen : bool, optional
         `True` (default): accept variable trial lengths and use all
         available trials and the samples in every trial.
@@ -228,6 +229,7 @@ def spike_psth(data,
     log_dict = {'bins': bins,
                 'binsize': binsize,
                 'latency': latency,
+                'output': output,
                 'vartriallen': vartriallen,
                 'numDiscard': numDiscard
                 }
@@ -243,6 +245,7 @@ def spike_psth(data,
                    trl_ends,
                    chan_unit_combs=combs,
                    tbins=bins,
+                   output=output,
                    samplerate=data.samplerate
                    )
 

--- a/syncopy/spikes/spike_psth.py
+++ b/syncopy/spikes/spike_psth.py
@@ -93,13 +93,10 @@ def spike_psth(data,
     new_cfg = get_frontend_cfg(defaults, lcls, kwargs)
 
     # digest selections
-
     if data.selection is not None:
         trl_def = data.selection.trialdefinition
         sinfo = data.selection.trialdefinition[:, :2]
-        # why is this not directly data.selection.trials?!
-        trials = Indexer(map(data._get_trial, data.selection.trial_ids),
-                         sinfo.shape[0])
+        trials = data.selection.trials
         trl_ivl = data.selection.trialintervals
         # beginnings and ends of all (selected) trials in trigger-relative time
         trl_starts, trl_ends = trl_ivl[:, 0], trl_ivl[:, 1]
@@ -194,10 +191,6 @@ def spike_psth(data,
         if data.selection is None:
             data.selectdata(trials=fit_trl_idx, inplace=True)
             # redefinition needed
-            trl_def = data.selection.trialdefinition
-            sinfo = data.selection.trialdefinition[:, :2]
-            trials = Indexer(map(data._get_trial, data.selection.trial_ids),
-                             sinfo.shape[0])
             numDiscard = len(trl_idx) - len(fit_trl_idx)
         else:
             # match fitting trials with selected ones
@@ -213,11 +206,12 @@ def spike_psth(data,
             select = data.selection.select.copy()
             select['trials'] = fit_trl_idx
             data.selectdata(select, inplace=True)
-            # now redefine local variables
-            trl_def = data.selection.trialdefinition
-            sinfo = data.selection.trialdefinition[:, :2]
-            trials = Indexer(map(data._get_trial, data.selection.trial_ids),
-                             sinfo.shape[0])
+
+        # now redefine local variables
+        trl_def = data.selection.trialdefinition
+        sinfo = data.selection.trialdefinition[:, :2]
+        trials = data.selection.trials
+
         msg = f"Discarded {numDiscard} trials which did not fit into latency window"
         SPYInfo(msg)
     else:

--- a/syncopy/spikes/spike_psth.py
+++ b/syncopy/spikes/spike_psth.py
@@ -162,8 +162,6 @@ def spike_psth(data,
     if not vartriallen:
         # trial idx for whole dataset
         trl_idx = np.arange(len(data.trials))
-        print(trl_starts)
-        print(trl_ends)
         bmask = (trl_starts <= window[0]) & (trl_ends >= window[1])
 
         # trials which fit completely into window

--- a/syncopy/spikes/spike_psth.py
+++ b/syncopy/spikes/spike_psth.py
@@ -105,22 +105,19 @@ def spike_psth(data,
         # why is this not directly data.selection.trials?!
         trials = Indexer(map(data._get_trial, data.selection.trials),
                          sinfo.shape[0])
+        trl_ivl = data.selection.trialintervals
+        # beginnings and ends of all (selected) trials in trigger-relative time
+        trl_starts, trl_ends = trl_ivl[:, 0], trl_ivl[:, 1]
+
     else:
         trl_def = data.trialdefinition
         sinfo = data.sampleinfo
         trials = data.trials
+        # beginnings and ends of all (selected) trials in trigger-relative time
+        trl_starts, trl_ends = data.trialintervals[:, 0], data.trialintervals[:, 1]
 
     # --- parse and digest `latency` (time window of analysis) ---
 
-    # beginnings and ends of all (selected) trials in trigger-relative time
-
-    # length in samples
-    beg_ends = sinfo - sinfo[:, 0][:, None]
-    # add offset and transform to seconds
-    beg_ends = (beg_ends + trl_def[:, 2][:, None]) / data.samplerate
-
-    trl_starts = beg_ends[:, 0]
-    trl_ends = beg_ends[:, 1]
     # just for sanity checks atm
     # tmin, tmax = trl_starts.min(), trl_ends.max()
 

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -189,7 +189,6 @@ def AR2_network(AdjMat=None, nSamples=1000, alphas=[0.55, -0.8]):
         solution of the network dynamics
     """
 
-
     # default system layout as in Dhamala 2008:
     # unidirectional (2->1) coupling
     if AdjMat is None:
@@ -252,7 +251,6 @@ def mk_RandomAdjMat(nChannels=3, conn_thresh=0.25, max_coupling=0.25):
         `nChannels` x `nChannels` adjacency matrix where
     """
 
-
     # random numbers in [0,1)
     AdjMat = np.random.random_sample((nChannels, nChannels))
 
@@ -279,7 +277,7 @@ def poisson_noise(nTrials=10,
                   nChannels=3,
                   nUnits=10,
                   intensity=.1,
-                  samplerate=30000
+                  samplerate=10000
                   ):
 
     """
@@ -326,6 +324,20 @@ def poisson_noise(nTrials=10,
     Notes
     -----
     Originally conceived by `Alejandro Tlaie Boria https://github.com/atlaie_`
+
+    Examples
+    --------
+    With `nSpikes=20_000`, `samplerate=10_000`, `nTrials=10` and the default `intensity=0.1`
+    we can expect a trial length of about 2 seconds:
+
+    >>> spike_data = poisson_noise(nTrials=10, nSpikes=20_000, samplerate=10_000)
+
+    Example output of the 1st trial lengths in seconds:
+
+    >>> spike_data.time[0][0], spike_data.time[0][-1]
+    >>> (-0.3004, 1.6459)
+
+    Which is close to 2 seconds.
 
     """
 

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -332,10 +332,10 @@ def poisson_noise(nTrials=10,
 
     >>> spike_data = poisson_noise(nTrials=10, nSpikes=20_000, samplerate=10_000)
 
-    Example output of the 1st trial lengths in seconds:
+    Example output of the 1st trial [start, end] in seconds:
 
-    >>> spike_data.time[0][0], spike_data.time[0][-1]
-    >>> (-0.3004, 1.6459)
+    >>> spike_data.trialintervals[0]
+    >>> array([-0.3004, 1.6459])
 
     Which is close to 2 seconds.
 
@@ -372,7 +372,7 @@ def poisson_noise(nTrials=10,
 
     shortest_trial = np.min(idx_end - idx_start)
     idx_offset = -np.random.choice(
-        np.arange(0.05 * shortest_trial, 0.2 * shortest_trial), size=nTrials, replace=True
+        np.arange(0.05 * shortest_trial, 0.2 * shortest_trial, dtype=int), size=nTrials, replace=True
     )
 
     trldef = np.vstack([idx_start, idx_end, idx_offset]).T

--- a/syncopy/tests/test_computationalroutine.py
+++ b/syncopy/tests/test_computationalroutine.py
@@ -248,7 +248,7 @@ class TestComputationalRoutine():
                 selected = self.sigdata.selectdata(**select)
             out_sel = filter_manager(selected, self.b, self.a,
                                      log_dict={"a": "this is a", "b": "this is b"})
-            assert len(out.trials) == len(out_sel.trial_ids)
+            assert len(out.trials) == len(out_sel.trials)
             assert "lowpass" in out._log
             assert "a = this is a" in out._log
             assert "b = this is b" in out._log

--- a/syncopy/tests/test_computationalroutine.py
+++ b/syncopy/tests/test_computationalroutine.py
@@ -147,7 +147,7 @@ class TestComputationalRoutine():
                 reference = self.orig
             else:
                 ref = []
-                for tk, trlno in enumerate(sel.trials):
+                for tk, trlno in enumerate(sel.trial_ids):
                     ref.append(self.origdata.trials[trlno][sel.time[tk], sel.channel])
                     # check for correct time selection
                     assert np.array_equal(out.time[tk], self.sigdata.time[trlno][sel.time[tk]])
@@ -172,11 +172,11 @@ class TestComputationalRoutine():
                 reference = self.orig[:self.t.size, :]
             else:
                 ref = np.zeros(out.trials[0].shape)
-                for tk, trlno in enumerate(sel.trials):
+                for tk, trlno in enumerate(sel.trial_ids):
                     ref += self.origdata.trials[trlno][sel.time[tk], sel.channel]
                     # check for correct time selection (accounting for trial-averaging)
                     assert np.array_equal(out.time[0], self.sigdata.time[0][sel.time[0]])
-                reference = ref / len(sel.trials)
+                reference = ref / len(sel.trial_ids)
             assert self.metrix[sk](np.abs(out.data - reference)) < self.tols[sk]
             assert np.array_equal(out.channel, self.sigdata.channel[sel.channel])
 
@@ -208,7 +208,7 @@ class TestComputationalRoutine():
 
                 # compare expected w/actual shape of computed data
                 reference = 0
-                for tk, trlno in enumerate(sel.trials):
+                for tk, trlno in enumerate(sel.trial_ids):
                     reference += nonequidata.trials[trlno][sel.time[tk]].shape[0]
                     # check for correct time selection
                     # FIXME: remove `if` below as soon as `time` prop for lists is fixed
@@ -235,7 +235,7 @@ class TestComputationalRoutine():
             out = filter_manager(self.sigdata, self.b, self.a, select=select,
                                  log_dict={"a": "this is a", "b": "this is b"})
 
-            assert len(out.trials) == len(sel.trials)
+            assert len(out.trials) == len(sel.trial_ids)
             # ensure our `log_dict` specification was respected
             assert "lowpass" in out._log
             assert "a = this is a" in out._log
@@ -248,7 +248,7 @@ class TestComputationalRoutine():
                 selected = self.sigdata.selectdata(**select)
             out_sel = filter_manager(selected, self.b, self.a,
                                      log_dict={"a": "this is a", "b": "this is b"})
-            assert len(out.trials) == len(out_sel.trials)
+            assert len(out.trials) == len(out_sel.trial_ids)
             assert "lowpass" in out._log
             assert "a = this is a" in out._log
             assert "b = this is b" in out._log
@@ -263,7 +263,7 @@ class TestComputationalRoutine():
                     reference = self.orig
                 else:
                     ref = []
-                    for tk, trlno in enumerate(sel.trials):
+                    for tk, trlno in enumerate(sel.trial_ids):
                         ref.append(self.origdata.trials[trlno][sel.time[tk], sel.channel])
                         assert np.array_equal(dummy.time[tk], self.sigdata.time[trlno][sel.time[tk]])
                     reference = np.vstack(ref)
@@ -302,7 +302,7 @@ class TestComputationalRoutine():
                         reference = self.orig
                     else:
                         ref = []
-                        for tk, trlno in enumerate(sel.trials):
+                        for tk, trlno in enumerate(sel.trial_ids):
                             ref.append(self.origdata.trials[trlno][sel.time[tk], sel.channel])
                             # check for correct time selection
                             assert np.array_equal(out.time[tk], self.sigdata.time[trlno][sel.time[tk]])
@@ -314,9 +314,9 @@ class TestComputationalRoutine():
                     if parallel_store:
                         nfiles = len(glob(os.path.join(os.path.splitext(out.filename)[0], "*.h5")))
                         if chan_per_worker is None:
-                            assert nfiles == len(sel.trials)
+                            assert nfiles == len(sel.trial_ids)
                         else:
-                            assert nfiles == len(sel.trials) * (int(out.channel.size /
+                            assert nfiles == len(sel.trial_ids) * (int(out.channel.size /
                                                                     chan_per_worker) +
                                                                 int(out.channel.size % chan_per_worker > 0))
 
@@ -341,11 +341,11 @@ class TestComputationalRoutine():
                         reference = self.orig[:self.t.size, :]
                     else:
                         ref = np.zeros(out.trials[0].shape)
-                        for tk, trlno in enumerate(sel.trials):
+                        for tk, trlno in enumerate(sel.trial_ids):
                             ref += self.origdata.trials[trlno][sel.time[tk], sel.channel]
                             # check for correct time selection (accounting for trial-averaging)
                             assert np.array_equal(out.time[0], self.sigdata.time[0][sel.time[0]])
-                        reference = ref / len(sel.trials)
+                        reference = ref / len(sel.trial_ids)
                     assert self.metrix[sk](np.abs(out.data - reference)) < self.tols[sk]
                     assert np.array_equal(out.channel, self.sigdata.channel[sel.channel])
                     assert out.data.is_virtual == False
@@ -387,7 +387,7 @@ class TestComputationalRoutine():
 
                         # compare expected w/actual shape of computed data
                         reference = 0
-                        for tk, trlno in enumerate(sel.trials):
+                        for tk, trlno in enumerate(sel.trial_ids):
                             reference += nonequidata.trials[trlno][sel.time[tk]].shape[0]
                             # check for correct time selection
                             # FIXME: remove `if` below as soon as `time` prop for lists is fixed
@@ -400,9 +400,9 @@ class TestComputationalRoutine():
                         if parallel_store:
                             nfiles = len(glob(os.path.join(os.path.splitext(out.filename)[0], "*.h5")))
                             if chan_per_worker is None:
-                                assert nfiles == len(sel.trials)
+                                assert nfiles == len(sel.trial_ids)
                             else:
-                                assert nfiles == len(sel.trials) * (int(out.channel.size /
+                                assert nfiles == len(sel.trial_ids) * (int(out.channel.size /
                                                                         chan_per_worker) +
                                                                     int(out.channel.size % chan_per_worker > 0))
 
@@ -431,7 +431,7 @@ class TestComputationalRoutine():
                                      log_dict={"a": "this is a", "b": "this is b"},
                                      parallel=True, parallel_store=parallel_store)
 
-                assert len(out.trials) == len(sel.trials)
+                assert len(out.trials) == len(sel.trial_ids)
                 # ensure our `log_dict` specification was respected
                 assert "lowpass" in out._log
                 assert "a = this is a" in out._log
@@ -446,7 +446,7 @@ class TestComputationalRoutine():
                                          log_dict={"a": "this is a", "b": "this is b"},
                                          parallel=True, parallel_store=parallel_store)
                 # only keyword args (`a` in this case here) are stored in `cfg`
-                assert len(out.trials) == len(sel.trials)
+                assert len(out.trials) == len(sel.trial_ids)
                 # ensure our `log_dict` specification was respected
                 assert "lowpass" in out._log
                 assert "a = this is a" in out._log
@@ -463,7 +463,7 @@ class TestComputationalRoutine():
                         reference = self.orig
                     else:
                         ref = []
-                        for tk, trlno in enumerate(sel.trials):
+                        for tk, trlno in enumerate(sel.trial_ids):
                             ref.append(self.origdata.trials[trlno][sel.time[tk], sel.channel])
                             assert np.array_equal(dummy.time[tk], self.sigdata.time[trlno][sel.time[tk]])
                         reference = np.vstack(ref)

--- a/syncopy/tests/test_continuousdata.py
+++ b/syncopy/tests/test_continuousdata.py
@@ -600,7 +600,7 @@ class TestAnalogData():
                         time.sleep(0.001)
                         selector = Selector(obj, kwdict)
                         idx[chanIdx] = selector.channel
-                        for tk, trialno in enumerate(selector.trials):
+                        for tk, trialno in enumerate(selector.trial_ids):
                             idx[timeIdx] = selector.time[tk]
                             assert np.array_equal(selected.trials[tk].squeeze(),
                                                   obj.trials[trialno][idx[0], :][:, idx[1]].squeeze())
@@ -838,7 +838,7 @@ class TestSpectralData():
                                 idx[chanIdx] = selector.channel
                                 idx[freqIdx] = selector.freq
                                 idx[taperIdx] = selector.taper
-                                for tk, trialno in enumerate(selector.trials):
+                                for tk, trialno in enumerate(selector.trial_ids):
                                     idx[timeIdx] = selector.time[tk]
                                     indexed = obj.trials[trialno][idx[0], ...][:, idx[1], ...][:, :, idx[2], :][..., idx[3]]
                                     assert np.array_equal(selected.trials[tk].squeeze(),
@@ -1086,7 +1086,7 @@ class TestCrossSpectralData():
                                 idx[freqIdx] = selector.freq
                                 jdx = [[elem] if np.issubdtype(type(elem), np.number) else elem for elem in idx]
                                 idx = jdx
-                                for tk, trialno in enumerate(selector.trials):
+                                for tk, trialno in enumerate(selector.trial_ids):
                                     idx[timeIdx] = selector.time[tk]
                                     indexed = obj.trials[trialno][idx[0], ...][:, idx[1], ...][:, :, idx[2], :][..., idx[3]]
                                     assert np.array_equal(selected.trials[tk].squeeze(),

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -223,7 +223,7 @@ class TestSpikeData():
                             selected = obj.selectdata(**kwdict)
                             selector = Selector(obj, kwdict)
                             tk = 0
-                            for trialno in selector.trials:
+                            for trialno in selector.trial_ids:
                                 if selector.time[tk]:
                                     assert np.array_equal(obj.trials[trialno][selector.time[tk], :],
                                                           selected.trials[tk])
@@ -580,7 +580,7 @@ class TestEventData():
                         selected = obj.selectdata(**kwdict)
                         selector = Selector(obj, kwdict)
                         tk = 0
-                        for trialno in selector.trials:
+                        for trialno in selector.trial_ids:
                             if selector.time[tk]:
                                 assert np.array_equal(obj.trials[trialno][selector.time[tk], :],
                                                       selected.trials[tk])

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -456,7 +456,7 @@ class TestSelector():
 
             # test trial selection
             selection = Selector(dummy, {"trials": [3, 1]})
-            assert selection.trials == [3, 1]
+            assert selection.trial_ids == [3, 1]
             selected = selectdata(dummy, trials=[3, 1])
             assert np.array_equal(selected.trials[0], dummy.trials[3])
             assert np.array_equal(selected.trials[1], dummy.trials[1])
@@ -465,7 +465,7 @@ class TestSelector():
 
             # scalar selection
             selection = Selector(dummy, {"trials": 2})
-            assert selection.trials == [2]
+            assert selection.trial_ids == [2]
             selected = selectdata(dummy, trials=2)
             assert np.array_equal(selected.trials[0], dummy.trials[2])
             assert selected.trialdefinition.shape == (1, 4)
@@ -473,7 +473,7 @@ class TestSelector():
 
             # array selection
             selection = Selector(dummy, {"trials": np.array([3, 1])})
-            assert selection.trials == [3, 1]
+            assert selection.trial_ids == [3, 1]
             selected = selectdata(dummy, trials=[3, 1])
             assert np.array_equal(selected.trials[0], dummy.trials[3])
             assert np.array_equal(selected.trials[1], dummy.trials[1])
@@ -483,7 +483,7 @@ class TestSelector():
             # select all
             for trlSec in [None, "all"]:
                 selection = Selector(dummy, {"trials": trlSec})
-                assert selection.trials == list(range(len(dummy.trials)))
+                assert selection.trial_ids == list(range(len(dummy.trials)))
                 selected = selectdata(dummy, trials=trlSec)
                 for tk, trl in enumerate(selected.trials):
                     assert np.array_equal(trl, dummy.trials[tk])

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -806,6 +806,50 @@ class TestSelector():
                     assert np.array_equal(selected.trials[trialno],
                                           spc.trials[trialno][tuple(spcIdx)])
 
+    def test_selector_trials(self):
+
+        ang = AnalogData(data=self.data["AnalogData"],
+                         trialdefinition=self.trl["AnalogData"],
+                         samplerate=self.samplerate)
+
+        # check original shapes
+        assert all([trl.shape[1] == self.nChannels for trl in ang.trials])
+        assert all([trl.shape[0] == self.lenTrial for trl in ang.trials])
+
+        # test inplace channel, trial and toilim selection
+        # ang.time[0] = array([0.5, 1. , 1.5, 2. , 2.5])
+        # this toilim selection hence takes the last two samples
+        select = {'channel': [2, 7, 9], 'trials': [0, 3, 5], 'toilim': [2, 3]}
+        ang.selectdata(**select, inplace=True)
+
+        # now check shapes and number of trials returned by Selector
+        # checks channel axis
+        assert all([trl.shape[1] == 3 for trl in ang.selection.trials])
+        # checks time axis
+        assert all([trl.shape[0] == 2 for trl in ang.selection.trials])
+        assert len(ang.selection.trials) == 3
+
+        # test for non-existing trials, trial indices are relative here!
+        select = {'trials': [0, 3, 5]}
+        ang.selectdata(**select, inplace=True)
+        assert ang.selection.trial_ids[2] == 5
+        # this returns original trial 6 (with index 5)
+        assert np.array_equal(ang.selection.trials[2], ang.trials[5])
+        # we only have 3 trials selected here, so max. relative index is 2
+        with pytest.raises(SPYValueError, match='less or equals 2'):
+            ang.selection.trials[5]
+
+        # Fancy indexing is not allowed so far
+        select = {'channel': [7, 7, 8]}
+        ang.selectdata(**select, inplace=True)
+        with pytest.raises(SPYValueError, match='fancy selection with repetition'):
+            ang.selection.trials[0]
+        select = {'channel': [7, 3, 8]}
+        ang.selectdata(**select, inplace=True)
+        with pytest.raises(SPYValueError, match='fancy non-ordered selection'):
+            ang.selection.trials[0]
+
+
     @skip_without_acme
     def test_parallel(self, testcluster):
         # collect all tests of current class and repeat them in parallel
@@ -816,3 +860,7 @@ class TestSelector():
             getattr(self, test)()
             flush_local_cluster(testcluster)
         client.close()
+
+
+if __name__ == '__main__':
+    T1 = TestSelector()

--- a/syncopy/tests/test_specest.py
+++ b/syncopy/tests/test_specest.py
@@ -258,7 +258,7 @@ class TestMTMFFT():
             elif "toi" in select:
                 nSamples = len(select["toi"])
             else:
-                nSamples = artdata.time[sel.trials[0]][sel.time[0]].size
+                nSamples = artdata.time[sel.trial_ids[0]][sel.time[0]].size
             freqs = np.fft.rfftfreq(nSamples, 1 / artdata.samplerate)
             assert spec.freq.size == freqs.size
             assert np.max(spec.freq - freqs) < self.ftol
@@ -288,7 +288,7 @@ class TestMTMFFT():
             elif "toi" in select:
                 nSamples = len(select["toi"])
             else:
-                nSamples = cfg.data.time[sel.trials[0]][sel.time[0]].size
+                nSamples = cfg.data.time[sel.trial_ids[0]][sel.time[0]].size
             freqs = np.fft.rfftfreq(nSamples, 1 / cfg.data.samplerate)
             assert spec.freq.size == freqs.size
             assert np.max(spec.freq - freqs) < self.ftol
@@ -321,7 +321,7 @@ class TestMTMFFT():
             elif "toi" in select:
                 nSamples = len(select["toi"])
             else:
-                nSamples = cfg.data.time[sel.trials[0]][sel.time[0]].size
+                nSamples = cfg.data.time[sel.trial_ids[0]][sel.time[0]].size
             freqs = np.fft.rfftfreq(nSamples, 1 / cfg.data.samplerate)
             assert spec.freq.size == freqs.size
             assert np.max(spec.freq - freqs) < self.ftol

--- a/syncopy/tests/test_specest.py
+++ b/syncopy/tests/test_specest.py
@@ -178,7 +178,7 @@ class TestMTMFFT():
                                 pad="nextpow2", output="pow", select=select)
 
             chanList = np.arange(self.nChannels)[sel.channel]
-            amps = np.empty((len(sel.trials) * len(chanList),))
+            amps = np.empty((len(sel.trial_ids) * len(chanList),))
             k = 0
             for nchan, chan in enumerate(chanList):
                 for ntrial in range(len(spec.trials)):

--- a/syncopy/tests/test_spike_psth.py
+++ b/syncopy/tests/test_spike_psth.py
@@ -21,8 +21,8 @@ class TestPSTH:
     spd = sd.poisson_noise(nTrials,
                            nUnits=3,
                            nChannels=2,
-                           nSpikes=1000,
-                           samplerate=10000)
+                           nSpikes=10_000,
+                           samplerate=10_000)
 
     def test_psth_binsize(self):
 

--- a/syncopy/tests/test_spike_psth.py
+++ b/syncopy/tests/test_spike_psth.py
@@ -3,19 +3,23 @@
 # Test Peri-Stimulus Time Histogram
 #
 
+import matplotlib.pyplot as ppl
 import numpy as np
+import pytest
 
 # syncopy imports
 import syncopy as spy
+from syncopy.shared.errors import SPYValueError
 from syncopy.tests import synth_data as sd
 from syncopy.spikes.spike_psth import available_outputs, available_latencies
+
 
 class TestPSTH:
 
     # synthetic spike data
     nTrials = 10
     spd = sd.poisson_noise(nTrials,
-                           nUnits=4,
+                           nUnits=3,
                            nChannels=2,
                            nSpikes=10000,
                            samplerate=10000)
@@ -27,10 +31,9 @@ class TestPSTH:
 
         # directly in seconds
         cfg.binsize = 0.2
-        counts = spy.spike_psth(self.spd,
-                                cfg,
-                                keeptrials=True)
+        counts = spy.spike_psth(self.spd, cfg)
 
+        assert isinstance(counts, spy.TimeLockData)
         # check that all trials have the same 'time locked' time axis
         # as enfored by TimeLockData.trialdefinition setter
         assert len(set([t.size for t in counts.time])) == 1
@@ -71,7 +74,7 @@ class TestPSTH:
 
         # -- bins stretch over the largest common time window --
         cfg.latency = 'maxperiod'  # frontend default
-        counts = spy.spike_psth(self.spd, cfg, keeptrials=True)
+        counts = spy.spike_psth(self.spd, cfg)
 
         # sampling interval for histogram output
         delta_t = 1 / counts.samplerate
@@ -87,7 +90,7 @@ class TestPSTH:
 
         # -- bins stretch over the minimal interval present in all trials --
         cfg.latency = 'minperiod'
-        counts = spy.spike_psth(self.spd, cfg, keeptrials=True)
+        counts = spy.spike_psth(self.spd, cfg)
 
         # check that histogram time points are less than 1
         # delta_t away from the minimal interval boundaries
@@ -100,13 +103,13 @@ class TestPSTH:
 
         # -- prestim --> only events with t < 0
         cfg.latency = 'prestim'
-        counts = spy.spike_psth(self.spd, cfg, keeptrials=True)
+        counts = spy.spike_psth(self.spd, cfg)
 
         assert np.all(counts.time[0] <= 0)
 
         # -- poststim --> only events with t > 0
         cfg.latency = 'poststim'
-        counts = spy.spike_psth(self.spd, cfg, keeptrials=True)
+        counts = spy.spike_psth(self.spd, cfg)
 
         assert np.all(counts.time[0] >= 0)
 
@@ -116,7 +119,7 @@ class TestPSTH:
         assert cfg.latency[0] < trl_starts.min()
         assert cfg.latency[1] > trl_ends.max()
 
-        counts = spy.spike_psth(self.spd, cfg, keeptrials=True)
+        counts = spy.spike_psth(self.spd, cfg)
         # check that histogram time points are less than 1
         # delta_t away from the manual set interval boundaries
         assert np.abs(cfg.latency[0] - counts.time[0][0]) <= delta_t
@@ -128,8 +131,182 @@ class TestPSTH:
         assert np.any(np.isnan(counts.data[:]))
 
     def test_psth_vartriallen(self):
-        pass 
-        # return counts
+
+        """
+        Test setting vartriallen to False excludes trials which
+        don't cover the latency time window
+        """
+
+        # everything else default
+        cfg = spy.StructDict()
+        cfg.vartriallen = False
+
+        starts, ends = self.spd.trialintervals[:, 0], self.spd.trialintervals[:, -1]
+
+        # choose latency which excludes 3 trials because
+        # of starting time (condition is <= latency)
+        cfg.latency = [np.sort(starts)[-4], ends.min()]
+        counts = spy.spike_psth(self.spd, cfg)
+
+        # check that 3 trials were excluded
+        assert len(self.spd.trials) - len(counts.trials) == 3
+
+        # choose latency which excludes 3 trials because
+        # of end time (condition is >= latency)
+        cfg.latency = [starts.max(), np.sort(ends)[3]]
+        counts = spy.spike_psth(self.spd, cfg)
+
+        # check that 3 trials were excluded
+        assert len(self.spd.trials) - len(counts.trials) == 3
+
+        # setting latency to 'maxperiod' with vartriallen=False
+        # excludes all trials which raises an error
+        cfg.latency = 'maxperiod'
+        with pytest.raises(SPYValueError,
+                           match='no trial that completely covers the latency window'):
+            counts = spy.spike_psth(self.spd, cfg)
+
+        # setting latency to 'minperiod' with vartriallen=False
+        # excludes no trials by definition of 'minperiod'
+        cfg.latency = 'minperiod'
+        counts = spy.spike_psth(self.spd, cfg)
+        # check that 0 trials were excluded
+        assert len(self.spd.trials) - len(counts.trials) == 0
+
+    def test_psth_outputs(self):
+
+        cfg = spy.StructDict()
+        cfg.latency = 'minperiod'  # to avoid NaNs
+        cfg.output = 'spikecount'
+        cfg.binsize = 0.1  # in seconds
+
+        counts = spy.spike_psth(self.spd, cfg)
+
+        # shows that each channel-unit combination
+        # has a flat distribution as expected for poisson noise
+        # however the absolute intensity differs: we have more and less
+        # active channels/units by synthetic data costruction
+        last_data = np.zeros(counts.time[0].size)
+        for chan in counts.channel:
+            bars = counts.show(trials=5, channel=chan)
+            ppl.bar(counts.time[0], bars, alpha=0.7, bottom=last_data,
+                    width=0.9 / counts.samplerate, label=chan)
+            # for stacking
+            last_data += bars
+        ppl.legend()
+        ppl.xlabel('time (s)')
+        ppl.ylabel('spike counts')
+        ppl.show()
+
+        cfg.output = 'rate'  # the default
+        rates = spy.spike_psth(self.spd, cfg)
+
+        # check that the rates are just the counts times samplerate
+        assert counts * counts.samplerate == rates
+
+        # this gives the spike histogram as normalized density
+        cfg.output = 'proportion'
+        cfg.latency = 'maxperiod'  # to provoke NaNs
+        spike_densities = spy.spike_psth(self.spd, cfg)
+
+        # check that there are NaNs as not all trials have data
+        # in this maximal interval (due to start/end randomization)
+        assert np.any(np.isnan(spike_densities.data[:]))
+
+        # check for one arbitrary trial should be enough
+        for chan in spike_densities.channel:
+            integral = np.nansum(spike_densities.show(trials=2, channel=chan))
+            assert np.allclose(integral, 1, atol=1e-3)
+
+    def test_psth_exceptions(self):
+
+        cfg = spy.StructDict()
+
+        # -- output validation --
+
+        # invalid string
+        cfg.output = 'counts'
+        with pytest.raises(SPYValueError,
+                           match="expected one of"):
+            spy.spike_psth(self.spd, cfg)
+
+        # invalid type
+        cfg.output = 12
+        with pytest.raises(SPYValueError,
+                           match="expected one of"):
+            spy.spike_psth(self.spd, cfg)
+
+        # -- binsize validation --
+
+        cfg.output = 'rate'
+        # no negative binsizes
+        cfg.binsize = -0.2
+        with pytest.raises(SPYValueError,
+                           match="expected value to be greater"):
+            spy.spike_psth(self.spd, cfg)
+
+        cfg.latency = [0, 0.2]
+        # binsize larger than time interval
+        cfg.binsize = 0.3
+        with pytest.raises(SPYValueError,
+                           match="less or equals 0.2"):
+            spy.spike_psth(self.spd, cfg)
+
+        # not available rule
+        cfg.binsize = 'sth'
+        with pytest.raises(SPYValueError,
+                           match="expected one of"):
+            spy.spike_psth(self.spd, cfg)
+
+        # -- latency validation --
+
+        cfg.binsize = 0.1
+        # not available latency
+        cfg.latency = 'sth'
+        with pytest.raises(SPYValueError,
+                           match="expected one of"):
+            spy.spike_psth(self.spd, cfg)
+
+        # latency not ordered
+        cfg.latency = [0.1, 0]
+        with pytest.raises(SPYValueError,
+                           match="expected start < end"):
+            spy.spike_psth(self.spd, cfg)
+
+        # latency completely outside of data
+        cfg.latency = [-999, -99]
+        with pytest.raises(SPYValueError,
+                           match="expected end of latency window"):
+            spy.spike_psth(self.spd, cfg)
+        cfg.latency = [99, 999]
+        with pytest.raises(SPYValueError,
+                           match="expected start of latency window"):
+            spy.spike_psth(self.spd, cfg)
+
+    def test_psth_chan_unit_mapping(self):
+        """
+        Test that non-existent channel/unit combinations
+        are accounted for correctly
+        """
+
+        # check that unit 1 really is there
+        assert np.any(self.spd.data[:, 2] == 1)
+        counts = spy.spike_psth(self.spd, output='spikecount')
+
+        # get rid of unit 1
+        pruned_spd = self.spd.selectdata(unit=[0, 2])
+        # check that unit 1 really is gone
+        assert np.all(pruned_spd.data[:, 2] != 1)
+
+        pruned_counts = spy.spike_psth(pruned_spd, output='spikecount')
+        # check that unit 1 really is gone
+        assert len(pruned_counts.channel) < len(counts.channel)
+        assert 'channel0_unit1' not in pruned_counts.channel
+        assert 'channel1_unit1' not in pruned_counts.channel
+
+        # check that counts for remaining channel/units are unchanged
+        for chan in pruned_counts.channel:
+            assert np.all(counts.show(trials=4, channel=chan) == pruned_counts.show(trials=4, channel=chan))
 
 
 if __name__ == '__main__':

--- a/syncopy/tests/test_spike_psth.py
+++ b/syncopy/tests/test_spike_psth.py
@@ -10,7 +10,6 @@ import syncopy as spy
 from syncopy.tests import synth_data as sd
 
 
-# === THIS IS A STUB ===
 class TestPSTH:
 
     # synthetic spike data

--- a/syncopy/tests/test_spike_psth.py
+++ b/syncopy/tests/test_spike_psth.py
@@ -8,7 +8,7 @@ import numpy as np
 # syncopy imports
 import syncopy as spy
 from syncopy.tests import synth_data as sd
-
+from syncopy.spikes.spike_psth import available_outputs, available_latencies
 
 class TestPSTH:
 
@@ -20,19 +20,70 @@ class TestPSTH:
                            nSpikes=10000,
                            samplerate=10000)
 
-    def test_psth(self):
+    def test_psth_binsize(self):
 
         cfg = spy.StructDict()
-        cfg.binsize = 0.3
-        cfg.latency = [-.5, 1.5]
+        cfg.latency = 'maxperiod'  # default
 
+        # directly in seconds
+        cfg.binsize = 0.2
         counts = spy.spike_psth(self.spd,
                                 cfg,
                                 keeptrials=True)
 
+        # check that all trials have the same 'time locked' time axis
+        # as enfored by TimeLockData.trialdefinition setter
+        assert len(set([t.size for t in counts.time])) == 1
+
+        # check that time steps correspond to binsize
         assert np.allclose(np.diff(counts.time[0]), cfg.binsize)
+
+        # automatic binsize selection
+        cfg.binsize = 'rice'
+        counts = spy.spike_psth(self.spd,
+                                cfg,
+                                keeptrials=True)
+        # number of bins is length of time axis
+        nBins_rice = counts.time[0].size
+        assert len(set([t.size for t in counts.time])) == 1
+
+        cfg.binsize = 'sqrt'
+        counts = spy.spike_psth(self.spd,
+                                cfg,
+                                keeptrials=True)
+        # number of bins is length of time axis
+        nBins_sqrt = counts.time[0].size
+        assert len(set([t.size for t in counts.time])) == 1
+
+        # sqrt rule gives more bins than Rice rule
+        assert nBins_sqrt > nBins_rice
+
+    def test_psth_latency(self):
+
+        cfg = spy.StructDict()
+        # directly in seconds
+        cfg.binsize = 0.1
+
+        sinfo = self.spd.sampleinfo
+        trl_def = self.spd.trialdefinition
+        # get trial starting and end times
+        beg_ends = sinfo + trl_def[:, 2][:, None]
+        beg_ends = (beg_ends - sinfo[:, 0][:, None]) / self.spd.samplerate
+
+        trl_starts = beg_ends[:, 0]
+        trl_ends = beg_ends[:, 1]
+
+        return beg_ends
+        
+        # bins stretch over the largest common time window
+        cfg.latency = 'maxperiod'  # default
+
+
+        counts = spy.spike_psth(self.spd,
+                                cfg,
+                                keeptrials=True)
+        
 
 
 if __name__ == '__main__':
     T1 = TestPSTH()
-

--- a/syncopy/tests/test_spike_psth.py
+++ b/syncopy/tests/test_spike_psth.py
@@ -64,25 +64,16 @@ class TestPSTH:
         # directly in seconds
         cfg.binsize = 0.1
 
-        sinfo = self.spd.sampleinfo
-        trl_def = self.spd.trialdefinition
-        # get trial starting and end times
-        beg_ends = sinfo + trl_def[:, 2][:, None]
-        beg_ends = (beg_ends - sinfo[:, 0][:, None]) / self.spd.samplerate
-
-        trl_starts = beg_ends[:, 0]
-        trl_ends = beg_ends[:, 1]
-
-        return beg_ends
-        
+        trl_starts = self.spd.trialintervals[:, 0]
+        trl_ends = self.spd.trialintervals[:, 1]
         # bins stretch over the largest common time window
         cfg.latency = 'maxperiod'  # default
-
-
         counts = spy.spike_psth(self.spd,
                                 cfg,
                                 keeptrials=True)
-        
+
+        return counts
+
 
 
 if __name__ == '__main__':

--- a/syncopy/tests/test_spike_psth.py
+++ b/syncopy/tests/test_spike_psth.py
@@ -21,7 +21,7 @@ class TestPSTH:
     spd = sd.poisson_noise(nTrials,
                            nUnits=3,
                            nChannels=2,
-                           nSpikes=10000,
+                           nSpikes=1000,
                            samplerate=10000)
 
     def test_psth_binsize(self):
@@ -317,3 +317,7 @@ class TestPSTH:
 
 if __name__ == '__main__':
     T1 = TestPSTH()
+    spd = T1.spd
+    trl0 = spd.trials[0]
+    spd.selectdata(unit=[0,2], inplace=True)
+    arr1 = spd.selection._get_trial(1)

--- a/syncopy/tests/test_spike_psth.py
+++ b/syncopy/tests/test_spike_psth.py
@@ -306,8 +306,14 @@ class TestPSTH:
 
         # check that counts for remaining channel/units are unchanged
         for chan in pruned_counts.channel:
-            assert np.all(counts.show(trials=4, channel=chan) == pruned_counts.show(trials=4, channel=chan))
+            assert np.array_equal(counts.show(trials=4, channel=chan),
+                                  pruned_counts.show(trials=4, channel=chan),
+                                  equal_nan=True)
 
+    def test_parallel_selection(self):
+
+        pass
+        # TODO: allow channel selection
 
 if __name__ == '__main__':
     T1 = TestPSTH()


### PR DESCRIPTION
## PSTH tests and `Selector.trials` addition

- new `obj.selection.trials` to access the (pruned by the selection) trials directly
- new `obj.trialintervals` and `obj.selection.trialintervals` to see relevant time interval of trials in seconds
- as usual, the real performance of our psth will only come to light when ppl use it
- @kshapcott and/or @atlaie feel free to blast in some (real) data :wink: 

addresses #175 

Author Guidelines
-----------------
- [ ] Is the change set **< 600 lines**?
- [x] Was the code checked for memory leaks/performance bottlenecks?
- [x] Is the code running locally **and** on the ESI cluster?
- [x] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do **parallel** loops have a set length and correct termination conditions?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [x] Code layout
  - [x] Is the code PEP8 compliant?
  - [x] Does the code adhere to agreed-upon naming conventions?
  - [x] Are keywords clearly named and easy to understand?
  - [x] No commented-out code?
- [x] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
