### PR TITLE
344 rng

### DIFF
--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -84,10 +84,10 @@ def freqanalysis(data, method='mtmfft', output='pow',
         * **keeptapers** : return individual tapers or average
         * **pad**: either pad to an absolute length or set to `'nextpow2'`
 
-        Post-processing of the resulting spectra with FOOOOF is available
+        Post-processing of the resulting spectra with FOOOF is available
         via setting `output` to one of `'fooof'`, `'fooof_aperiodic'` or
         `'fooof_peaks'`, see below for details. The returned spectrum represents
-        the full foofed spectrum for `'fooof'`, the aperiodic
+        the full fooofed spectrum for `'fooof'`, the aperiodic
         fit for `'fooof_aperiodic'`, and the peaks (Gaussians fit to them) for
         `'fooof_peaks'`. Returned data is in linear scale. Noisy input
         data will most likely lead to fitting issues with fooof, always inspect
@@ -909,7 +909,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
         #  - the output_fmt must be one of 'fooof', 'fooof_aperiodic',
         #    or 'fooof_peaks'.
         #  - everything passed as method_kwargs is passed as arguments
-        #    to the foooof.FOOOF() constructor or functions, the other args are
+        #    to the fooof.FOOOF() constructor or functions, the other args are
         #    used elsewhere.
         fooofMethod = FooofSpy(output_fmt=output_fooof, fooof_settings=fooof_settings, method_kwargs=fooof_kwargs)
 

--- a/syncopy/tests/backend/test_conn.py
+++ b/syncopy/tests/backend/test_conn.py
@@ -191,7 +191,7 @@ def test_wilson():
     CSDav = np.zeros((nSamples // 2 + 1, nChannels, nChannels), dtype=np.complex64)
     for _ in range(nTrials):
 
-        sol = synth_data.AR2_network(nSamples=nSamples)
+        sol = synth_data.AR2_network(nSamples=nSamples, seed=None)
         # --- get the (single trial) CSD ---
 
         CSD, freqs = csd.csd(sol, fs,

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -233,7 +233,7 @@ def AR2_network(AdjMat=None, nSamples=1000, alphas=[0.55, -0.8], seed=None):
 
     for i in range(2, nSamples):
         sol[i, :] = (DiagMat + AdjMat.T) @ sol[i - 1, :] + alpha2 * sol[i - 2, :]
-        sol[i, :] += rng.random((nChannels))
+        sol[i, :] += rng.normal(size=(nChannels))
 
     return sol
 

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -231,11 +231,11 @@ def AR2_network(AdjMat=None, nSamples=1000, alphas=[0.55, -0.8], seed=None):
     sol = np.zeros((nSamples, nChannels))
     # pick the 1st values at random
     rng = np.random.default_rng(seed)
-    sol[:2, :] = rng.randn(2, nChannels)
+    sol[:2, :] = rng.random((2, nChannels))
 
     for i in range(2, nSamples):
         sol[i, :] = (DiagMat + AdjMat.T) @ sol[i - 1, :] + alpha2 * sol[i - 2, :]
-        sol[i, :] += rng.randn(nChannels)
+        sol[i, :] += rng.random((nChannels))
 
     return sol
 

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -67,7 +67,7 @@ def collect_trials(trial_generator):
             for trial_idx in range(nTrials):
                 if 'seed' in signature(trial_generator).parameters.keys():
                     if seed_array is not None:
-                        tg_kwargs['seed'] = seed[trial_idx]
+                        tg_kwargs['seed'] = seed_array[trial_idx]
                     else:
                         tg_kwargs['seed'] = seed
                 trl_arr = trial_generator(**tg_kwargs)

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -87,7 +87,7 @@ def white_noise(nSamples=1000, nChannels=2, seed=None):
     Plain white noise with unity standard deviation
     """
     rng = np.random.default_rng(seed)
-    return rng.random((nSamples, nChannels))
+    return rng.normal(size=(nSamples, nChannels))
 
 
 @collect_trials

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -370,22 +370,24 @@ def poisson_noise(nTrials=10,
     """
 
     # uniform random weights
-    def get_rdm_weights(size):
-        pvec = np.random.uniform(size=size)
+    def get_rdm_weights(size, seed=seed):
+        rng = np.random.default_rng(seed)
+        pvec = rng.uniform(size=size)
         return pvec / pvec.sum()
 
     # total length of all trials combined
+    rng = np.random.default_rng(seed)
     T_max = int(nSpikes / intensity)
 
-    spike_samples = np.sort(random.sample(range(T_max), nSpikes))
-    channels = np.random.choice(
+    spike_samples = np.sort(rng.random(size=(range(T_max), nSpikes)))
+    channels = rng.choice(
         np.arange(nChannels), p=get_rdm_weights(nChannels),
         size=nSpikes, replace=True
     )
 
     uvec = np.arange(nUnits)
     pvec = get_rdm_weights(nUnits)
-    units = np.random.choice(uvec, p=pvec, size=nSpikes, replace=True)
+    units = rng.choice(uvec, p=pvec, size=nSpikes, replace=True)
 
     # originally fixed trial size
     step = T_max // nTrials
@@ -396,10 +398,10 @@ def poisson_noise(nTrials=10,
     idx_end = trl_intervals[1:] - 1
 
     # now randomize trial length a bit, max 10% size difference
-    idx_end = idx_end - np.r_[np.random.randint(step // 10, size=nTrials - 1), 0]
+    idx_end = idx_end - np.r_[rng.integers(step // 10, size=nTrials - 1), 0]
 
     shortest_trial = np.min(idx_end - idx_start)
-    idx_offset = -np.random.choice(
+    idx_offset = -rng.choice(
         np.arange(0.05 * shortest_trial, 0.2 * shortest_trial, dtype=int), size=nTrials, replace=True
     )
 

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -121,7 +121,7 @@ def phase_diffusion(freq,
                     nChannels=2,
                     nSamples=1000,
                     return_phase=False,
-                    ):
+                    seed = None):
 
     """
     Linear (harmonic) phase evolution + a Brownian noise term
@@ -160,7 +160,7 @@ def phase_diffusion(freq,
     """
 
     # white noise
-    wn = white_noise(nSamples=nSamples, nChannels=nChannels)
+    wn = white_noise(nSamples=nSamples, nChannels=nChannels, seed=seed)
 
     delta_ts = np.ones(nSamples) * 1 / fs
     omega0 = 2 * np.pi * freq

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -97,14 +97,12 @@ def linear_trend(y_max, nSamples=1000, nChannels=2):
     """
     A linear trend  on all channels from 0 to `y_max` in `nSamples`
     """
-
     trend = np.linspace(0, y_max, nSamples)
     return np.column_stack([trend for _ in range(nChannels)])
 
 
 @collect_trials
 def harmonic(freq, samplerate, nSamples=1000, nChannels=2):
-
     """
     A harmonic with frequency `freq`
     """
@@ -162,7 +160,8 @@ def phase_diffusion(freq,
     """
 
     # white noise
-    wn = np.random.randn(nSamples, nChannels)
+    rng = np.random.default_rng(seed)
+    wn = rng.random((nSamples, nChannels))
 
     delta_ts = np.ones(nSamples) * 1 / fs
     omega0 = 2 * np.pi * freq
@@ -308,7 +307,8 @@ def poisson_noise(nTrials=10,
                   nChannels=3,
                   nUnits=10,
                   intensity=.1,
-                  samplerate=10000
+                  samplerate=10000,
+                  seed=None
                   ):
 
     """

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -31,10 +31,12 @@ def collect_trials(trial_generator):
     a `samplerate`, forward this directly.
 
     If the underlying trial generating function also accepts
-    a `seed`, forward this directly. One can pass a single seed,
-    to be used for all trials, or a list/np.ndarray of seeds with
-    len/size equal to nTrials, with one seed per trial. Leaving
-    at the default value, None, will select a random seed each time,
+    a `seed`, forward this directly. One can set `seed_per_trial=False` to use
+    the same seed for all trials, or leave `seed_per_trial=True` (the default),
+    to have this function internally generate a list
+    of seeds with len equal to `nTrials` from the given seed, with one seed per trial.
+
+    One can set the `seed` to `None`, which will select a random seed each time,
     (and it will differ between trials).
 
     The default `nTrials=None` is the identity wrapper and
@@ -43,7 +45,7 @@ def collect_trials(trial_generator):
     """
 
     @functools.wraps(trial_generator)
-    def wrapper_synth(nTrials=None, samplerate=1000, seed=None, seed_per_trial=True, **tg_kwargs):
+    def wrapper_synth(nTrials=None, samplerate=1000, seed=42, seed_per_trial=True, **tg_kwargs):
 
         use_seed_per_trial = False
         if nTrials is not None and seed is not None and seed_per_trial:  # Use the single seed to create one seed per trial.
@@ -70,7 +72,6 @@ def collect_trials(trial_generator):
                         tg_kwargs['seed'] = seed[trial_idx]
                     else:
                         tg_kwargs['seed'] = seed
-                print(f"[collect_trials] use_seed_per_trial={use_seed_per_trial}. Calling {trial_generator.__name__} with kwargs: {tg_kwargs}")
                 trl_arr = trial_generator(**tg_kwargs)
                 trl_list.append(trl_arr)
 

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -158,7 +158,7 @@ def phase_diffusion(freq,
     """
 
     # white noise
-    wn = white_noise(nSamples=1000, nChannels=2)
+    wn = white_noise(nSamples=nSamples, nChannels=nChannels)
 
     delta_ts = np.ones(nSamples) * 1 / fs
     omega0 = 2 * np.pi * freq

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -122,7 +122,8 @@ def phase_diffusion(freq,
                     fs=1000,
                     nChannels=2,
                     nSamples=1000,
-                    return_phase=False):
+                    return_phase=False,
+                    seed=None):
 
     """
     Linear (harmonic) phase evolution + a Brownian noise term

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -229,7 +229,7 @@ def AR2_network(AdjMat=None, nSamples=1000, alphas=[0.55, -0.8], seed=None):
     sol = np.zeros((nSamples, nChannels))
     # pick the 1st values at random
     rng = np.random.default_rng(seed)
-    sol[:2, :] = rng.random((2, nChannels))
+    sol[:2, :] = rng.normal(size=(2, nChannels))
 
     for i in range(2, nSamples):
         sol[i, :] = (DiagMat + AdjMat.T) @ sol[i - 1, :] + alpha2 * sol[i - 2, :]

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -46,7 +46,7 @@ def collect_trials(trial_generator):
     def wrapper_synth(nTrials=None, samplerate=1000, seed=None, seed_per_trial=True, **tg_kwargs):
 
         use_seed_per_trial = False
-        if seed is not None and seed_per_trial:  # Use the single seed to create one seed per trial.
+        if nTrials is not None and seed is not None and seed_per_trial:  # Use the single seed to create one seed per trial.
             rng = np.random.default_rng(seed)
             seed = rng.integers(1000000, size=nTrials)
             use_seed_per_trial = True
@@ -55,12 +55,10 @@ def collect_trials(trial_generator):
         if 'samplerate' in signature(trial_generator).parameters.keys():
             tg_kwargs['samplerate'] = samplerate
 
-        if 'seed' in signature(trial_generator).parameters.keys():
-            if not use_seed_per_trial:
-                tg_kwargs['seed'] = seed
-
         # do nothing (may pass on the scalar seed if the function supports it)
         if nTrials is None:
+            if 'seed' in signature(trial_generator).parameters.keys():
+                tg_kwargs['seed'] = seed
             return trial_generator(**tg_kwargs)
         # collect trials
         else:

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -158,7 +158,7 @@ def phase_diffusion(freq,
     """
 
     # white noise
-    wn = white_noise(nSamples=1000, nChannels=2, seed=seed)
+    wn = white_noise(nSamples=1000, nChannels=2)
 
     delta_ts = np.ones(nSamples) * 1 / fs
     omega0 = 2 * np.pi * freq

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -122,7 +122,7 @@ def harmonic(freq, samplerate, nSamples=1000, nChannels=2):
 @collect_trials
 def phase_diffusion(freq,
                     eps=.1,
-                    fs=1000,
+                    samplerate=1000,
                     nChannels=2,
                     nSamples=1000,
                     return_phase=False,
@@ -133,7 +133,7 @@ def phase_diffusion(freq,
     inducing phase diffusion around the deterministic phase drift with
     slope ``2pi * freq`` (angular frequency).
 
-    The linear phase increments are given by ``dPhase = 2pi * freq/fs``,
+    The linear phase increments are given by ``dPhase = 2pi * freq/samplerate``,
     the Brownian increments are scaled with `eps` relative to these
     phase increments.
 
@@ -146,7 +146,7 @@ def phase_diffusion(freq,
         `1` means the single Wiener step
         has on average the size of the
         harmonic increments
-    fs : float
+    samplerate : float
         Sampling rate in Hz
     nChannels : int
         Number of channels
@@ -168,12 +168,12 @@ def phase_diffusion(freq,
     # white noise
     wn = white_noise(nSamples=nSamples, nChannels=nChannels, seed=seed)
 
-    delta_ts = np.ones(nSamples) * 1 / fs
+    delta_ts = np.ones(nSamples) * 1 / samplerate
     omega0 = 2 * np.pi * freq
     lin_incr = np.tile(omega0 * delta_ts, (nChannels, 1)).T
 
     # relative Brownian increments
-    rel_eps = np.sqrt(omega0 / fs * eps)
+    rel_eps = np.sqrt(omega0 / samplerate * eps)
     brown_incr = rel_eps * wn
     phases = np.cumsum(lin_incr + brown_incr, axis=0)
     if not return_phase:
@@ -250,14 +250,14 @@ def AR2_network(AdjMat=None, nSamples=1000, alphas=[0.55, -0.8], seed=None):
     return sol
 
 
-def AR2_peak_freq(a1, a2, fs=1):
+def AR2_peak_freq(a1, a2, samplerate=1):
     """
     Helper function to tune spectral peak of AR(2) process
     """
     if np.any((a1**2 + 4 * a2) > 0):
         raise ValueError("No complex roots!")
 
-    return np.arccos(a1 * (a2 - 1) / (4 * a2)) * 1 / _2pi * fs
+    return np.arccos(a1 * (a2 - 1) / (4 * a2)) * 1 / _2pi * samplerate
 
 
 def mk_RandomAdjMat(nChannels=3, conn_thresh=0.25, max_coupling=0.25, seed=None):

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -305,8 +305,7 @@ def poisson_noise(nTrials=10,
                   nUnits=10,
                   intensity=.1,
                   samplerate=10000,
-                  seed=None
-                  ):
+                  seed=None):
 
     """
     Poisson (Shot-)noise generator

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -379,7 +379,7 @@ def poisson_noise(nTrials=10,
     rng = np.random.default_rng(seed)
     T_max = int(nSpikes / intensity)
 
-    spike_samples = np.sort(rng.random(size=(range(T_max), nSpikes)))
+    spike_samples = np.sort(rng.choice(range(T_max), size=nSpikes, replace=False))
     channels = rng.choice(
         np.arange(nChannels), p=get_rdm_weights(nChannels),
         size=nSpikes, replace=True

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -53,9 +53,6 @@ def collect_trials(trial_generator):
         if 'seed' in signature(trial_generator).parameters.keys():
             if not seed_per_trial:
                 tg_kwargs['seed'] = seed
-        else:
-            if seed_per_trial:
-                SPYInfo(f"Ignoring seed list/array, trial_generator does not support 'seed' parameter.")
 
         # do nothing
         if nTrials is None:
@@ -71,6 +68,7 @@ def collect_trials(trial_generator):
             for trial_idx in range(nTrials):
                 if 'seed' in signature(trial_generator).parameters.keys() and seed_per_trial:
                     tg_kwargs['seed'] = seed[trial_idx]
+                print(f"[collect_trials] Calling {trial_generator.__name__} with kwargs: {tg_kwargs}")
                 trl_arr = trial_generator(**tg_kwargs)
                 trl_list.append(trl_arr)
 
@@ -121,7 +119,7 @@ def phase_diffusion(freq,
                     nChannels=2,
                     nSamples=1000,
                     return_phase=False,
-                    seed=None):
+                    ):
 
     """
     Linear (harmonic) phase evolution + a Brownian noise term
@@ -160,8 +158,7 @@ def phase_diffusion(freq,
     """
 
     # white noise
-    rng = np.random.default_rng(seed)
-    wn = rng.random((nSamples, nChannels))
+    wn = white_noise(nSamples=1000, nChannels=2, seed=seed)
 
     delta_ts = np.ones(nSamples) * 1 / fs
     omega0 = 2 * np.pi * freq

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -65,8 +65,11 @@ def collect_trials(trial_generator):
             trl_list = []
 
             for trial_idx in range(nTrials):
-                if 'seed' in signature(trial_generator).parameters.keys() and use_seed_per_trial:
-                    tg_kwargs['seed'] = seed[trial_idx]
+                if 'seed' in signature(trial_generator).parameters.keys():
+                    if use_seed_per_trial:
+                        tg_kwargs['seed'] = seed[trial_idx]
+                    else:
+                        tg_kwargs['seed'] = seed
                 print(f"[collect_trials] use_seed_per_trial={use_seed_per_trial}. Calling {trial_generator.__name__} with kwargs: {tg_kwargs}")
                 trl_arr = trial_generator(**tg_kwargs)
                 trl_list.append(trl_arr)

--- a/syncopy/tests/synth_data.py
+++ b/syncopy/tests/synth_data.py
@@ -151,6 +151,8 @@ def phase_diffusion(freq,
         Number of samples in time
     return_phase : bool, optional
         If set to true returns the phases in radians
+    seed: None or int, passed on to `np.random.default_rng`.
+          Set to an int to get reproducible results.
 
     Returns
     -------
@@ -250,7 +252,7 @@ def AR2_peak_freq(a1, a2, fs=1):
     return np.arccos(a1 * (a2 - 1) / (4 * a2)) * 1 / _2pi * fs
 
 
-def mk_RandomAdjMat(nChannels=3, conn_thresh=0.25, max_coupling=0.25):
+def mk_RandomAdjMat(nChannels=3, conn_thresh=0.25, max_coupling=0.25, seed=None):
     """
     Create a random adjacency matrix
     for the network of AR(2) processes
@@ -270,6 +272,8 @@ def mk_RandomAdjMat(nChannels=3, conn_thresh=0.25, max_coupling=0.25):
         Total input into single channel
         normalized by number of couplings
         (for stability).
+    seed: None or int, passed on to `np.random.default_rng`.
+          Set to an int to get reproducible results.
 
     Returns
     -------
@@ -278,7 +282,8 @@ def mk_RandomAdjMat(nChannels=3, conn_thresh=0.25, max_coupling=0.25):
     """
 
     # random numbers in [0,1)
-    AdjMat = np.random.random_sample((nChannels, nChannels))
+    rng = np.random.default_rng(seed)
+    AdjMat = rng.random((nChannels, nChannels))
 
     # all smaller than threshold elements get set to 1 (coupled)
     AdjMat = (AdjMat < conn_thresh).astype(float)

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -58,7 +58,8 @@ class TestGranger:
     data = synth_data.AR2_network(nTrials,
                                   AdjMat=AdjMat,
                                   nSamples=nSamples,
-                                  samplerate=fs)
+                                  samplerate=fs,
+                                  seed=42)
     time_span = [-1, nSamples / fs - 1]   # -1s offset
     foi = np.arange(5, 75)   # in Hz
 

--- a/syncopy/tests/test_metadata.py
+++ b/syncopy/tests/test_metadata.py
@@ -28,7 +28,7 @@ if __acme__:
 skip_without_acme = pytest.mark.skipif(not __acme__, reason="acme not available")
 
 
-def _get_fooof_signal(nTrials=100, nChannels = 1, nSamples = 1000):
+def _get_fooof_signal(nTrials=100, nChannels = 1, nSamples = 1000, seed=None):
     """
     Produce suitable test signal for fooof, with peaks at 30 and 50 Hz.
 
@@ -38,9 +38,9 @@ def _get_fooof_signal(nTrials=100, nChannels = 1, nSamples = 1000):
     Returns AnalogData instance.
     """
     samplerate = 1000
-    ar1_part = AR2_network(AdjMat=np.zeros(nChannels), nSamples=nSamples, alphas=[0.9, 0], nTrials=nTrials)
-    pd1 = phase_diffusion(freq=30., eps=.1, fs=samplerate, nChannels=nChannels, nSamples=nSamples, nTrials=nTrials)
-    pd2 = phase_diffusion(freq=50., eps=.1, fs=samplerate, nChannels=nChannels, nSamples=nSamples, nTrials=nTrials)
+    ar1_part = AR2_network(AdjMat=np.zeros(nChannels), nSamples=nSamples, alphas=[0.9, 0], nTrials=nTrials, seed=seed)
+    pd1 = phase_diffusion(freq=30., eps=.1, fs=samplerate, nChannels=nChannels, nSamples=nSamples, nTrials=nTrials, seed=seed)
+    pd2 = phase_diffusion(freq=50., eps=.1, fs=samplerate, nChannels=nChannels, nSamples=nSamples, nTrials=nTrials, seed=seed)
     signal = ar1_part + .8 * pd1 + 0.6 * pd2
     return signal
 

--- a/syncopy/tests/test_metadata.py
+++ b/syncopy/tests/test_metadata.py
@@ -39,8 +39,8 @@ def _get_fooof_signal(nTrials=100, nChannels = 1, nSamples = 1000, seed=None):
     """
     samplerate = 1000
     ar1_part = AR2_network(AdjMat=np.zeros(nChannels), nSamples=nSamples, alphas=[0.9, 0], nTrials=nTrials, seed=seed)
-    pd1 = phase_diffusion(freq=30., eps=.1, fs=samplerate, nChannels=nChannels, nSamples=nSamples, nTrials=nTrials, seed=seed)
-    pd2 = phase_diffusion(freq=50., eps=.1, fs=samplerate, nChannels=nChannels, nSamples=nSamples, nTrials=nTrials, seed=seed)
+    pd1 = phase_diffusion(freq=30., eps=.1, samplerate=samplerate, nChannels=nChannels, nSamples=nSamples, nTrials=nTrials, seed=seed)
+    pd2 = phase_diffusion(freq=50., eps=.1, samplerate=samplerate, nChannels=nChannels, nSamples=nSamples, nTrials=nTrials, seed=seed)
     signal = ar1_part + .8 * pd1 + 0.6 * pd2
     return signal
 

--- a/syncopy/tests/test_specest_fooof.py
+++ b/syncopy/tests/test_specest_fooof.py
@@ -88,7 +88,8 @@ class TestFooofSpy():
     one of the available FOOOF output types.
     """
 
-    tfData = _get_fooof_signal()
+    seed = 42
+    tfData = _get_fooof_signal(seed=seed)
 
     @staticmethod
     def get_fooof_cfg():
@@ -112,7 +113,7 @@ class TestFooofSpy():
         cfg = TestFooofSpy.get_fooof_cfg()
         cfg['foilim'] = [0., 100.]    # Include the zero in tfData.
         with pytest.raises(SPYValueError) as err:
-            _ = freqanalysis(cfg, _get_fooof_signal())  # tfData contains zero.
+            _ = freqanalysis(cfg, _get_fooof_signal(seed=self.seed))  # tfData contains zero.
         assert "a frequency range that does not include zero" in str(err.value)
 
     def test_output_fooof_works_with_freq_zero_in_data_after_setting_foilim(self):
@@ -125,7 +126,7 @@ class TestFooofSpy():
         cfg = TestFooofSpy.get_fooof_cfg()
         cfg.pop('fooof_opt', None)
         fooof_opt = {'peak_width_limits': (1.0, 12.0)}  # Increase lower limit to avoid fooof warning.
-        spec_dt = freqanalysis(cfg, _get_fooof_signal(), fooof_opt=fooof_opt)
+        spec_dt = freqanalysis(cfg, _get_fooof_signal(seed=self.seed), fooof_opt=fooof_opt)
 
         # check frequency axis
         assert spec_dt.freq.size == 100
@@ -158,7 +159,7 @@ class TestFooofSpy():
         cfg.output = "fooof_aperiodic"
         cfg.pop('fooof_opt', None)
         fooof_opt = {'peak_width_limits': (1.0, 12.0)}  # Increase lower limit to avoid fooof warning.
-        spec_dt = freqanalysis(cfg, _get_fooof_signal(), fooof_opt=fooof_opt)
+        spec_dt = freqanalysis(cfg, _get_fooof_signal(seed=self.seed), fooof_opt=fooof_opt)
 
         # log
         assert "fooof" in spec_dt._log  # from the method
@@ -176,7 +177,7 @@ class TestFooofSpy():
         cfg.output = "fooof_peaks"
         cfg.pop('fooof_opt', None)
         fooof_opt = {'peak_width_limits': (1.0, 12.0)}  # Increase lower limit to avoid fooof warning.
-        spec_dt = freqanalysis(cfg, _get_fooof_signal(), fooof_opt=fooof_opt)
+        spec_dt = freqanalysis(cfg, _get_fooof_signal(seed=self.seed), fooof_opt=fooof_opt)
         assert spec_dt.data.ndim == 4
         assert "fooof" in spec_dt._log
         assert "fooof_method = fooof_peaks" in spec_dt._log
@@ -191,13 +192,13 @@ class TestFooofSpy():
         fooof_opt = {'peak_width_limits': (6.0, 12.0),
                      'min_peak_height': 0.2}  # Increase lower limit to avoid fooof warning.
 
-        out_fft = freqanalysis(cfg, _get_fooof_signal())
+        out_fft = freqanalysis(cfg, _get_fooof_signal(seed=self.seed))
         cfg['output'] = "fooof"
-        out_fooof = freqanalysis(cfg, _get_fooof_signal(), fooof_opt=fooof_opt)
+        out_fooof = freqanalysis(cfg, _get_fooof_signal(seed=self.seed), fooof_opt=fooof_opt)
         cfg['output'] = "fooof_aperiodic"
-        out_fooof_aperiodic = freqanalysis(cfg, _get_fooof_signal(), fooof_opt=fooof_opt)
+        out_fooof_aperiodic = freqanalysis(cfg, _get_fooof_signal(seed=self.seed), fooof_opt=fooof_opt)
         cfg['output'] = "fooof_peaks"
-        out_fooof_peaks = freqanalysis(cfg, _get_fooof_signal(), fooof_opt=fooof_opt)
+        out_fooof_peaks = freqanalysis(cfg, _get_fooof_signal(seed=self.seed), fooof_opt=fooof_opt)
 
         assert (out_fooof.freq == out_fooof_aperiodic.freq).all()
         assert (out_fooof.freq == out_fooof_peaks.freq).all()
@@ -219,7 +220,7 @@ class TestFooofSpy():
         cfg.output = "fooof_peaks"
         cfg.pop('fooof_opt', None)
         fooof_opt = {'max_n_peaks': 8, 'peak_width_limits': (1.0, 12.0)}
-        spec_dt = freqanalysis(cfg, _get_fooof_signal(), fooof_opt=fooof_opt)
+        spec_dt = freqanalysis(cfg, _get_fooof_signal(seed=self.seed), fooof_opt=fooof_opt)
 
         assert spec_dt.data.ndim == 4
 

--- a/syncopy/tests/test_specest_fooof.py
+++ b/syncopy/tests/test_specest_fooof.py
@@ -212,7 +212,7 @@ class TestFooofSpy():
         assert 27 < out_fooof_peaks.freq[f1_ind] < 33
 
         plot_data = {"Raw input data": np.ravel(out_fft.data), "Fooofed spectrum": np.ravel(out_fooof.data), "Fooof aperiodic fit": np.ravel(out_fooof_aperiodic.data), "Fooof peaks fit": np.ravel(out_fooof_peaks.data)}
-        #_plot_powerspec_linear(freqs, powers=plot_data, title="Outputs from different fooof methods for ar1 data (linear scale)")
+        _plot_powerspec_linear(freqs, powers=plot_data, title="Outputs from different fooof methods for ar1 data (linear scale)")
 
     def test_frontend_settings_are_merged_with_defaults_used_in_backend(self):
         cfg = TestFooofSpy.get_fooof_cfg()

--- a/syncopy/tests/test_specest_fooof.py
+++ b/syncopy/tests/test_specest_fooof.py
@@ -124,7 +124,7 @@ class TestFooofSpy():
         """
         cfg = TestFooofSpy.get_fooof_cfg()
         cfg.pop('fooof_opt', None)
-        fooof_opt = {'peak_width_limits': (1.0, 12.0)}  # Increase lower limit to avoid foooof warning.
+        fooof_opt = {'peak_width_limits': (1.0, 12.0)}  # Increase lower limit to avoid fooof warning.
         spec_dt = freqanalysis(cfg, _get_fooof_signal(), fooof_opt=fooof_opt)
 
         # check frequency axis
@@ -157,7 +157,7 @@ class TestFooofSpy():
         cfg = TestFooofSpy.get_fooof_cfg()
         cfg.output = "fooof_aperiodic"
         cfg.pop('fooof_opt', None)
-        fooof_opt = {'peak_width_limits': (1.0, 12.0)}  # Increase lower limit to avoid foooof warning.
+        fooof_opt = {'peak_width_limits': (1.0, 12.0)}  # Increase lower limit to avoid fooof warning.
         spec_dt = freqanalysis(cfg, _get_fooof_signal(), fooof_opt=fooof_opt)
 
         # log
@@ -175,7 +175,7 @@ class TestFooofSpy():
         cfg = TestFooofSpy.get_fooof_cfg()
         cfg.output = "fooof_peaks"
         cfg.pop('fooof_opt', None)
-        fooof_opt = {'peak_width_limits': (1.0, 12.0)}  # Increase lower limit to avoid foooof warning.
+        fooof_opt = {'peak_width_limits': (1.0, 12.0)}  # Increase lower limit to avoid fooof warning.
         spec_dt = freqanalysis(cfg, _get_fooof_signal(), fooof_opt=fooof_opt)
         assert spec_dt.data.ndim == 4
         assert "fooof" in spec_dt._log
@@ -189,7 +189,7 @@ class TestFooofSpy():
         cfg['foilim'] = [10, 70]
         cfg.pop('fooof_opt', None)
         fooof_opt = {'peak_width_limits': (6.0, 12.0),
-                     'min_peak_height': 0.2}  # Increase lower limit to avoid foooof warning.
+                     'min_peak_height': 0.2}  # Increase lower limit to avoid fooof warning.
 
         out_fft = freqanalysis(cfg, _get_fooof_signal())
         cfg['output'] = "fooof"

--- a/syncopy/tests/test_spike_psth.py
+++ b/syncopy/tests/test_spike_psth.py
@@ -17,12 +17,13 @@ from syncopy.shared.errors import SPYValueError
 from syncopy.tests import synth_data as sd
 from syncopy.spikes.spike_psth import available_outputs, available_latencies
 
-def get_spike_data(nTrials = 10):
+def get_spike_data(nTrials = 10, seed=None):
     return sd.poisson_noise(nTrials,
                            nUnits=3,
                            nChannels=2,
                            nSpikes=10_000,
-                           samplerate=10_000)
+                           samplerate=10_000,
+                           seed=seed)
 def get_spike_cfg():
     cfg = spy.StructDict()
     cfg.binsize = 0.3
@@ -33,7 +34,7 @@ def get_spike_cfg():
 class TestPSTH:
 
     # synthetic spike data
-    spd = get_spike_data()
+    spd = get_spike_data(seed=42)
 
     def test_psth_binsize(self):
 

--- a/syncopy/tests/test_synth_data.py
+++ b/syncopy/tests/test_synth_data.py
@@ -22,8 +22,8 @@ class TestSynthData:
         """Without seed set, the data should not be identical.
            Note: This does not use collect trials.
         """
-        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels)
-        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels)
+        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=None)
+        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=None)
         assert isinstance(wn1, np.ndarray)
         assert isinstance(wn2, np.ndarray)
 
@@ -88,8 +88,8 @@ class TestSynthData:
            Note: This does not use collect trials.
         """
         num_channels = 2
-        arn1 = AR2_network(nSamples=self.nSamples)  # 2 channels, via default adj matrix
-        arn2 = AR2_network(nSamples=self.nSamples)
+        arn1 = AR2_network(nSamples=self.nSamples, seed=None)  # 2 channels, via default adj matrix
+        arn2 = AR2_network(nSamples=self.nSamples, seed=None)
         assert isinstance(arn1, np.ndarray)
         assert isinstance(arn2, np.ndarray)
         assert arn1.shape == (self.nSamples, num_channels)

--- a/syncopy/tests/test_synth_data.py
+++ b/syncopy/tests/test_synth_data.py
@@ -102,7 +102,6 @@ class TestSynthData:
         """With seed set, the data should be identical.
            Note: This does not use collect trials.
         """
-        num_channels = 2
         seed = 42
         arn1 = AR2_network(nSamples=self.nSamples, seed=seed)
         arn2 = AR2_network(nSamples=self.nSamples, seed=seed)

--- a/syncopy/tests/test_synth_data.py
+++ b/syncopy/tests/test_synth_data.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+#
+# Ensure synthetic data generator functions used in tests work as expected.
+#
+
+# Builtin/3rd party package imports
+import numpy as np
+import pytest
+
+from syncopy.tests.synth_data import white_noise
+from syncopy.shared.errors import SPYValueError
+import syncopy as spy
+
+class TestSynthData:
+
+    nTrials=100
+    nChannels = 1
+    nSamples = 1000
+    samplerate = 1000
+
+    def test_white_noise_without_seed(self):
+        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels)
+        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels)
+        assert isinstance(wn1, np.ndarray)
+        assert isinstance(wn2, np.ndarray)
+
+        assert not np.allclose(wn1, wn2)
+
+    def test_white_noise_with_seed(self):
+        seed = 42
+        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=seed)
+        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=seed)
+        assert isinstance(wn1, np.ndarray)
+        assert isinstance(wn2, np.ndarray)
+
+        assert np.allclose(wn1, wn2)
+
+    def test_collect_trials_seed_array(self):
+        # Trials must differ within an object if seed is a list/ndarray:
+        seed = np.random.RandomState(0).randn(self.nTrials)
+        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
+        assert isinstance(wn1, spy.AnalogData)
+        assert not np.allclose(wn1.show(trials=0), wn1.show(trials=1))
+
+        # However, using the same seed for a new instance must lead to identical trials between instances:
+        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
+        assert np.allclose(wn1.show(trials=0), wn2.show(trials=0))
+        assert np.allclose(wn1.show(trials=1), wn2.show(trials=1))
+
+    def test_collect_trials_seed_scalar(self):
+        # Trials must be identical within an object if seed is a single scalar.
+        seed = 42
+        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
+        assert isinstance(wn1, spy.AnalogData)
+        assert np.allclose(wn1.show(trials=0), wn1.show(trials=1))
+
+        # And also, using the same scalar seed again should lead to an identical object.
+        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
+        assert np.allclose(wn1.show(trials=0), wn2.show(trials=0))
+        assert np.allclose(wn1.show(trials=1), wn2.show(trials=1))
+
+    def test_collect_trials_no_seed(self):
+        # Trials must differ within an object if seed is None:
+        seed = None
+        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
+        assert isinstance(wn1, spy.AnalogData)
+        assert not np.allclose(wn1.show(trials=0), wn1.show(trials=1))
+
+        # And instances must also differ:
+        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
+        assert not np.allclose(wn1.show(trials=0), wn2.show(trials=0))
+        assert not np.allclose(wn1.show(trials=1), wn2.show(trials=1))
+
+
+    def test_collect_trials_raise_wrong_seed(self):
+        with pytest.raises(SPYValueError, match="Seed list/array with length equal to nTrials"):
+            white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=20, seed=np.arange(21))
+
+
+
+
+if __name__ == '__main__':
+    T1 = TestSynthData()

--- a/syncopy/tests/test_synth_data.py
+++ b/syncopy/tests/test_synth_data.py
@@ -93,8 +93,8 @@ class TestSynthData:
         arn2 = AR2_network(nSamples=self.nSamples)
         assert isinstance(arn1, np.ndarray)
         assert isinstance(arn2, np.ndarray)
-        assert arn1.shape == (2, num_channels)
-        assert arn2.shape == (2, num_channels)
+        assert arn1.shape == (self.nSamples, num_channels)
+        assert arn2.shape == (self.nSamples, num_channels)
 
         assert not np.allclose(arn1, arn2)
 

--- a/syncopy/tests/test_synth_data.py
+++ b/syncopy/tests/test_synth_data.py
@@ -31,7 +31,7 @@ class TestSynthData:
 
     def test_white_noise_with_seed(self):
         """With seed set, the data should be identical.
-           Note: This does not use collect trials.
+           Note: This does not use @collect_trials.
         """
         seed = 42
         wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=seed)
@@ -42,8 +42,9 @@ class TestSynthData:
         assert np.allclose(wn1, wn2)
 
     def test_collect_trials_wn_seed_array(self):
-        # Trials must differ within an object if seed is a list/ndarray:
-        seed = np.random.randint(10000, size=self.nTrials)
+        """Uses @collect_trials."""
+        # Trials must differ within an object if seed_per_trial is left at default (true):
+        seed = 42
         wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
         assert isinstance(wn1, spy.AnalogData)
         assert not np.allclose(wn1.show(trials=0), wn1.show(trials=1))
@@ -54,18 +55,20 @@ class TestSynthData:
         assert np.allclose(wn1.show(trials=1), wn2.show(trials=1))
 
     def test_collect_trials_wn_seed_scalar(self):
-        # Trials must be identical within an object if seed is a single scalar.
+        """Uses @collect_trials."""
+        # Trials must be identical within an object if seed_per_trial is False (and a seed is used).
         seed = 42
-        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
+        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed, seed_per_trial=False)
         assert isinstance(wn1, spy.AnalogData)
         assert np.allclose(wn1.show(trials=0), wn1.show(trials=1))
 
         # And also, using the same scalar seed again should lead to an identical object.
-        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
+        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed, seed_per_trial=False)
         assert np.allclose(wn1.show(trials=0), wn2.show(trials=0))
         assert np.allclose(wn1.show(trials=1), wn2.show(trials=1))
 
     def test_collect_trials_wn_no_seed(self):
+        """Uses @collect_trials."""
         # Trials must differ within an object if seed is None:
         seed = None
         wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
@@ -77,10 +80,6 @@ class TestSynthData:
         assert not np.allclose(wn1.show(trials=0), wn2.show(trials=0))
         assert not np.allclose(wn1.show(trials=1), wn2.show(trials=1))
 
-
-    def test_collect_trials_wn_raise_wrong_seed(self):
-        with pytest.raises(SPYValueError, match="Seed list/array with length equal to nTrials"):
-            white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=20, seed=np.arange(21))
 
     #### Tests for AR2_network
 
@@ -103,8 +102,8 @@ class TestSynthData:
            Note: This does not use collect trials.
         """
         seed = 42
-        arn1 = AR2_network(nSamples=self.nSamples, seed=seed)
-        arn2 = AR2_network(nSamples=self.nSamples, seed=seed)
+        arn1 = AR2_network(nSamples=self.nSamples, seed=seed, seed_per_trial=False)
+        arn2 = AR2_network(nSamples=self.nSamples, seed=seed, seed_per_trial=False)
 
         assert np.allclose(arn1, arn2)
 

--- a/syncopy/tests/test_synth_data.py
+++ b/syncopy/tests/test_synth_data.py
@@ -37,7 +37,7 @@ class TestSynthData:
 
     def test_collect_trials_seed_array(self):
         # Trials must differ within an object if seed is a list/ndarray:
-        seed = np.random.RandomState(0).randn(self.nTrials)
+        seed = np.random.randint(10000, size=self.nTrials)
         wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
         assert isinstance(wn1, spy.AnalogData)
         assert not np.allclose(wn1.show(trials=0), wn1.show(trials=1))

--- a/syncopy/tests/test_synth_data.py
+++ b/syncopy/tests/test_synth_data.py
@@ -7,7 +7,7 @@
 import numpy as np
 import pytest
 
-from syncopy.tests.synth_data import white_noise
+from syncopy.tests.synth_data import white_noise, AR2_network
 from syncopy.shared.errors import SPYValueError
 import syncopy as spy
 
@@ -19,6 +19,9 @@ class TestSynthData:
     samplerate = 1000
 
     def test_white_noise_without_seed(self):
+        """Without seed set, the data should not be identical.
+           Note: This does not use collect trials.
+        """
         wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels)
         wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels)
         assert isinstance(wn1, np.ndarray)
@@ -27,6 +30,9 @@ class TestSynthData:
         assert not np.allclose(wn1, wn2)
 
     def test_white_noise_with_seed(self):
+        """With seed set, the data should be identical.
+           Note: This does not use collect trials.
+        """
         seed = 42
         wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=seed)
         wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=seed)
@@ -35,7 +41,7 @@ class TestSynthData:
 
         assert np.allclose(wn1, wn2)
 
-    def test_collect_trials_seed_array(self):
+    def test_collect_trials_wn_seed_array(self):
         # Trials must differ within an object if seed is a list/ndarray:
         seed = np.random.randint(10000, size=self.nTrials)
         wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
@@ -47,7 +53,7 @@ class TestSynthData:
         assert np.allclose(wn1.show(trials=0), wn2.show(trials=0))
         assert np.allclose(wn1.show(trials=1), wn2.show(trials=1))
 
-    def test_collect_trials_seed_scalar(self):
+    def test_collect_trials_wn_seed_scalar(self):
         # Trials must be identical within an object if seed is a single scalar.
         seed = 42
         wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
@@ -59,7 +65,7 @@ class TestSynthData:
         assert np.allclose(wn1.show(trials=0), wn2.show(trials=0))
         assert np.allclose(wn1.show(trials=1), wn2.show(trials=1))
 
-    def test_collect_trials_no_seed(self):
+    def test_collect_trials_wn_no_seed(self):
         # Trials must differ within an object if seed is None:
         seed = None
         wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=self.nTrials, seed=seed)
@@ -72,12 +78,36 @@ class TestSynthData:
         assert not np.allclose(wn1.show(trials=1), wn2.show(trials=1))
 
 
-    def test_collect_trials_raise_wrong_seed(self):
+    def test_collect_trials_wn_raise_wrong_seed(self):
         with pytest.raises(SPYValueError, match="Seed list/array with length equal to nTrials"):
             white_noise(nSamples=self.nSamples, nChannels=self.nChannels, nTrials=20, seed=np.arange(21))
 
+    #### Tests for AR2_network
 
+    def test_ar2_without_seed(self):
+        """Without seed set, the data should not be identical.
+           Note: This does not use collect trials.
+        """
+        num_channels = 2
+        arn1 = AR2_network(nSamples=self.nSamples)  # 2 channels, via default adj matrix
+        arn2 = AR2_network(nSamples=self.nSamples)
+        assert isinstance(arn1, np.ndarray)
+        assert isinstance(arn2, np.ndarray)
+        assert arn1.shape == (2, num_channels)
+        assert arn2.shape == (2, num_channels)
 
+        assert not np.allclose(arn1, arn2)
+
+    def test_ar2_with_seed(self):
+        """With seed set, the data should be identical.
+           Note: This does not use collect trials.
+        """
+        num_channels = 2
+        seed = 42
+        arn1 = AR2_network(nSamples=self.nSamples, seed=seed)
+        arn2 = AR2_network(nSamples=self.nSamples, seed=seed)
+
+        assert np.allclose(arn1, arn2)
 
 if __name__ == '__main__':
     T1 = TestSynthData()


### PR DESCRIPTION
Adds option to get reproducible data from all synth_data functions by setting a seed.

* This is implemented by adding a new `seed` parameter to all functions.
* Special care has been taken with the `@collect_trials` wrapper: typically you do **not** want all trials to be identical, even if you want your data to be reproducible (e.g., when you average white noise from 100 trials, you do not want to get a clear signal). To achieve this, the boolean parameter `seed_per_trial` has been added to the `@collect_trials` wrapper, and is on by default. When on, it ensures that you get reproducible data that *differs* between trials. If you want identical trials, set `seed_per_trial=False`.
    - Obviously, if you don't reproducible data at all, don't pass a seed (or use `None` as the seed).


Author Guidelines
-----------------
- [x] Is the change set **< 600 lines**?
- [x] Was the code checked for memory leaks/performance bottlenecks?
- [x] Is the code running locally **and** on the ESI cluster?
- [x] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do **parallel** loops have a set length and correct termination conditions?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [ ] Code layout
  - [ ] Is the code PEP8 compliant?
  - [ ] Does the code adhere to agreed-upon naming conventions?
  - [ ] Are keywords clearly named and easy to understand?
  - [ ] No commented-out code?
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
