### PR TITLE
349 plotting does not support custom dimords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### NEW
-- Added additional .info entries for Granger analysis, indicating details about the computation
-- Added additional .info entries for FoooF results, e.i. Gaussian fit parameters
+- Added additional .info entries for Granger analysis, indicating details about the computation.
+- Added additional .info entries for FoooF results, e.g. Gaussian fit parameters.
+- Fix bug #365, plotting supports custom dimords now.
 
 ### CHANGED
 - Maximal brute force regularization parameter for Granger increased to 1e-1

--- a/syncopy/nwanalysis/AV_compRoutines.py
+++ b/syncopy/nwanalysis/AV_compRoutines.py
@@ -55,7 +55,7 @@ def normalize_csd_cF(csd_av_dat,
     csd_av_dat : (1, nFreq, N, N) :class:`numpy.ndarray`
         Cross-spectral densities for `N` x `N` channels
         and `nFreq` frequencies averaged over trials.
-    output : {'abs', 'pow', 'fourier'}, default: 'abs'
+    output : {'abs', 'pow', 'fourier', 'real', 'imag'}, default: 'abs'
         Also after normalization the coherency is still complex (`'complex'`),
         to get the real valued coherence ``0 < C_ij(f) < 1`` one can either take the
         absolute (`'abs'`) or the absolute squared (`'pow'`) values of the

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -191,6 +191,11 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         lgl = "'" + "or '".join(opt + "' " for opt in availableMethods)
         raise SPYValueError(legal=lgl, varname="method", actual=method)
 
+    # output selection is only valid for coherence
+    if method != 'coh' and output != defaults['output']:
+        msg = f"Setting `output` for method {method} has not effect!"
+        SPYWarning(msg)
+
     # if a subset selection is present
     # get sampleinfo and check for equidistancy
     if data.selection is not None:
@@ -242,7 +247,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
             raise SPYValueError(lgl, 'foi/foilim', actual)
 
         nChannels = len(data.channel)
-        nTrials = len(lenTrials)
+        nTrials = np.size(lenTrials)
         # warn user if this ratio is not small
         if nChannels / nTrials > 0.1:
             msg = "Multi-channel Granger analysis can be numerically unstable, it is recommended to have at least 10 times the number of trials compared to the number of channels. Try calculating in sub-groups of fewer channels!"

--- a/syncopy/plotting/_helpers.py
+++ b/syncopy/plotting/_helpers.py
@@ -74,7 +74,7 @@ def parse_toi(dataobject, trl, show_kwargs):
     dataobject.selectdata(inplace=True, **show_kwargs)
 
     # still have to index the single trial
-    idx = dataobject.selection.time[0]
+    idx = dataobject.selection.time[trl]
 
     # index selection, again the single trial
     time = dataobject.time[trl][idx]

--- a/syncopy/plotting/_helpers.py
+++ b/syncopy/plotting/_helpers.py
@@ -73,8 +73,8 @@ def parse_toi(dataobject, trl, show_kwargs):
     # apply the selection
     dataobject.selectdata(inplace=True, **show_kwargs)
 
-    # still have to index the single trial
-    idx = dataobject.selection.time[trl]
+    # still have to index the only and single trial
+    idx = dataobject.selection.time[0]
 
     # index selection, again the single trial
     time = dataobject.time[trl][idx]

--- a/syncopy/plotting/_helpers.py
+++ b/syncopy/plotting/_helpers.py
@@ -147,6 +147,21 @@ def get_method(dataobject):
         return meth_str
 
 
+def get_output(dataobject):
+
+    """
+    Returns the method string from
+    the log of a Syncopy data object
+    """
+
+    # get the method string in a capture group
+    pattern = re.compile(r'[\s\w\D]+output = (\w+)')
+    match = pattern.match(dataobject._log)
+    if match:
+        output_str = match.group(1)
+        return output_str
+
+
 def calc_multi_layout(nAx):
 
     """

--- a/syncopy/plotting/mp_plotting.py
+++ b/syncopy/plotting/mp_plotting.py
@@ -253,9 +253,9 @@ def plot_CrossSpectralData(data, **show_kwargs):
     # get the data to plot
     data_y = data.show(**show_kwargs)
 
-    # create the axes and figure if needed
-    # persistent axes allows for plotting different
-    # channel combinations into the same figure
+    # Create the axes and figure if needed.
+    # Persistent axes allow for plotting different
+    # channel combinations into the same figure.
     if not hasattr(data, 'ax'):
         fig, data.ax = _plotting.mk_line_figax(xlabel, ylabel)
     _plotting.plot_lines(data.ax, data_x, data_y, label=label)

--- a/syncopy/plotting/mp_plotting.py
+++ b/syncopy/plotting/mp_plotting.py
@@ -46,7 +46,7 @@ def plot_AnalogData(data, shifted=True, **show_kwargs):
         trl = 0
 
     # get the data to plot
-    data_x = plot_helpers.parse_toi(data, trl, show_kwargs)    
+    data_x = plot_helpers.parse_toi(data, trl, show_kwargs)
     data_y = data.show(**show_kwargs)
     # 'time' and 'channel' are the only axes
     if data._defaultDimord != data.dimord:
@@ -241,8 +241,10 @@ def plot_CrossSpectralData(data, **show_kwargs):
     data_y = data.show(**show_kwargs)
 
     # create the axes and figure if needed
-    # persisten axes allows for plotting different
+    # persistent axes allows for plotting different
     # channel combinations into the same figure
     if not hasattr(data, 'ax'):
         fig, data.ax = _plotting.mk_line_figax(xlabel, ylabel)
     _plotting.plot_lines(data.ax, data_x, data_y, label=label)
+
+    return fig, data.ax

--- a/syncopy/plotting/mp_plotting.py
+++ b/syncopy/plotting/mp_plotting.py
@@ -176,7 +176,7 @@ def plot_SpectralData(data, **show_kwargs):
             data_y = np.log10(data.show(**show_kwargs))
             ylabel = 'power (dB)'
         elif output in ['fourier', 'complex']:
-            SPYWarning("Can't plot complex valued spectra, choose 'real' or 'imag' as output!\nAbort plotting..")
+            SPYWarning("Can't plot complex valued spectra, choose 'real' or 'imag' as output! Aborting plotting.")
             return
         else:
             data_y = data.show(**show_kwargs)

--- a/syncopy/plotting/mp_plotting.py
+++ b/syncopy/plotting/mp_plotting.py
@@ -169,10 +169,21 @@ def plot_SpectralData(data, **show_kwargs):
 
         # get the data to plot
         data_x = plot_helpers.parse_foi(data, show_kwargs)
-        data_y = np.log10(data.show(**show_kwargs))
+        output = plot_helpers.get_output(data)
+
+        # only log10 the absolute squared spectra
+        if output == 'pow':
+            data_y = np.log10(data.show(**show_kwargs))
+            ylabel = 'power (dB)'
+        elif output in ['fourier', 'complex']:
+            SPYWarning("Can't plot complex valued spectra, choose 'real' or 'imag' as output!\nAbort plotting..")
+            return
+        else:
+            data_y = data.show(**show_kwargs)
+            ylabel = f'{output}'
 
         fig, axs = _plotting.mk_multi_line_figax(nrows, ncols, xlabel='frequency (Hz)',
-                                                 ylabel='power (dB)')
+                                                 ylabel=ylabel)
 
         for chan_dat, ax, label in zip(data_y.T, axs.flatten(), labels):
             _plotting.plot_lines(ax, data_x, chan_dat, label=label, leg_fontsize=pltConfig['mLegendSize'])

--- a/syncopy/plotting/mp_plotting.py
+++ b/syncopy/plotting/mp_plotting.py
@@ -46,8 +46,11 @@ def plot_AnalogData(data, shifted=True, **show_kwargs):
         trl = 0
 
     # get the data to plot
-    data_x = plot_helpers.parse_toi(data, trl, show_kwargs)
+    data_x = plot_helpers.parse_toi(data, trl, show_kwargs)    
     data_y = data.show(**show_kwargs)
+    # 'time' and 'channel' are the only axes
+    if data._defaultDimord != data.dimord:
+        data_y = data_y.T
 
     if data_y.size == 0:
         lgl = "Selection with non-zero size"
@@ -63,7 +66,7 @@ def plot_AnalogData(data, shifted=True, **show_kwargs):
         return
 
     elif nAx > pltConfig['mMaxAxes']:
-        SPYWarning("Please select max. {pltConfig['mMaxAxes']} channels for a multipanelplot!")
+        SPYWarning(f"Please select max. {pltConfig['mMaxAxes']} channels for a multipanelplot!")
         return
     else:
         # determine axes layout, prefer columns over rows due to display aspect ratio

--- a/syncopy/plotting/mp_plotting.py
+++ b/syncopy/plotting/mp_plotting.py
@@ -218,6 +218,8 @@ def plot_CrossSpectralData(data, **show_kwargs):
 
     # what data do we have?
     method = plot_helpers.get_method(data)
+    output = plot_helpers.get_output(data)
+
     if method == 'granger':
         xlabel = 'frequency (Hz)'
         ylabel = 'Granger causality'
@@ -225,7 +227,7 @@ def plot_CrossSpectralData(data, **show_kwargs):
         data_x = plot_helpers.parse_foi(data, show_kwargs)
     elif method == 'coh':
         xlabel = 'frequency (Hz)'
-        ylabel = 'coherence'
+        ylabel = f'{output} coherence'
         label = rf"channel{chi} - channel{chj}"
         data_x = plot_helpers.parse_foi(data, show_kwargs)
     elif method == 'corr':

--- a/syncopy/plotting/sp_plotting.py
+++ b/syncopy/plotting/sp_plotting.py
@@ -114,7 +114,7 @@ def plot_SpectralData(data, **show_kwargs):
         if not isinstance(label, str):
             SPYWarning("Please select a single channel for plotting!\nAbort plotting..")
             return
-        
+
         # here we always need a new axes
         fig, ax = _plotting.mk_img_figax()
 
@@ -123,7 +123,7 @@ def plot_SpectralData(data, **show_kwargs):
         time = plot_helpers.parse_toi(data, trl, show_kwargs)
         freqs = plot_helpers.parse_foi(data, show_kwargs)
 
-        # custom dimords for SpectralData not supported atm        
+        # custom dimords for SpectralData not supported atm
         # dimord is time x taper x freq x channel
         # need freq x time for plotting
         data_yx = data.show(**show_kwargs).T
@@ -246,3 +246,5 @@ def plot_CrossSpectralData(data, **show_kwargs):
     data.ax.legend(ncol=1)
 
     data.fig.tight_layout()
+
+    return data.fig, data.ax

--- a/syncopy/plotting/sp_plotting.py
+++ b/syncopy/plotting/sp_plotting.py
@@ -52,6 +52,9 @@ def plot_AnalogData(data, shifted=True, **show_kwargs):
 
     # get the data to plot
     data_y = data.show(**show_kwargs)
+    # 'time' and 'channel' are the only axes
+    if data._defaultDimord != data.dimord:
+        data_y = data_y.T
     if data_y.size == 0:
         lgl = "Selection with non-zero size"
         act = "got zero samples"
@@ -103,10 +106,15 @@ def plot_SpectralData(data, **show_kwargs):
     if method in ('wavelet', 'superlet', 'mtmconvol'):
         # multiple channels?
         label = plot_helpers.parse_channel(data, show_kwargs)
-        if not isinstance(label, str):
-            SPYWarning("Please select a single channel for plotting!")
+        # only relevant for mtmconvol
+        if 'taper' in show_kwargs:
+            SPYWarning("Taper selection not supported for time-frequency spectra!\nAbort plotting..")
             return
 
+        if not isinstance(label, str):
+            SPYWarning("Please select a single channel for plotting!\nAbort plotting..")
+            return
+        
         # here we always need a new axes
         fig, ax = _plotting.mk_img_figax()
 
@@ -115,6 +123,7 @@ def plot_SpectralData(data, **show_kwargs):
         time = plot_helpers.parse_toi(data, trl, show_kwargs)
         freqs = plot_helpers.parse_foi(data, show_kwargs)
 
+        # custom dimords for SpectralData not supported atm        
         # dimord is time x taper x freq x channel
         # need freq x time for plotting
         data_yx = data.show(**show_kwargs).T

--- a/syncopy/plotting/sp_plotting.py
+++ b/syncopy/plotting/sp_plotting.py
@@ -19,10 +19,8 @@ from syncopy.plotting.config import pltErrMsg, pltConfig
 
 @plot_helpers.revert_selection
 def plot_AnalogData(data, shifted=True, **show_kwargs):
-
     """
-    The probably simplest plot, a 2d-line
-    plot of selected channels
+    Simple 2d-line plot of selected channels.
 
     Parameters
     ----------
@@ -31,21 +29,20 @@ def plot_AnalogData(data, shifted=True, **show_kwargs):
 
     Returns
     -------
-    fig : `~matplotlib.figure.Figure`
-
-    ax : `~matplotlib.axes.Axes`
+    fig : `matplotlib.figure.Figure` instance (or `None` in case of errors), the plot figure.
+    ax  : `matplotlib.axes.Axes` instance (or `None` in case of errors), the plot axes.
     """
 
     if not __plt__:
         SPYWarning(pltErrMsg)
-        return
+        return None, None
 
     # right now we have to enforce
     # single trial selection only
     trl = show_kwargs.get('trials', None)
     if not isinstance(trl, Number) and len(data.trials) > 1:
-        SPYWarning("Please select a single trial for plotting!")
-        return
+        SPYWarning("Please select a single trial for plotting.")
+        return None, None
     # only 1 trial so no explicit selection needed
     elif len(data.trials) == 1:
         trl = 0
@@ -74,7 +71,6 @@ def plot_AnalogData(data, shifted=True, **show_kwargs):
 
 @plot_helpers.revert_selection
 def plot_SpectralData(data, **show_kwargs):
-
     """
     Plot either a 2d-line plot in case of
     singleton time axis or an image plot
@@ -84,18 +80,23 @@ def plot_SpectralData(data, **show_kwargs):
     ----------
     data : :class:`~syncopy.datatype.SpectralData`
     show_kwargs : :func:`~syncopy.datatype.methods.show.show` arguments
+
+    Returns
+    -------
+    fig : `matplotlib.figure.Figure` instance (or `None` in case of errors), the plot figure.
+    ax  : `matplotlib.axes.Axes` instance (or `None` in case of errors), the plot axes.
     """
 
     if not __plt__:
         SPYWarning(pltErrMsg)
-        return
+        return None, None
 
     # right now we have to enforce
     # single trial selection only
     trl = show_kwargs.get('trials', None)
     if not isinstance(trl, Number) and len(data.trials) > 1:
-        SPYWarning("Please select a single trial for plotting!")
-        return
+        SPYWarning("Please select a single trial for plotting.")
+        return None, None
     elif len(data.trials) == 1:
         trl = 0
 
@@ -108,12 +109,12 @@ def plot_SpectralData(data, **show_kwargs):
         label = plot_helpers.parse_channel(data, show_kwargs)
         # only relevant for mtmconvol
         if 'taper' in show_kwargs:
-            SPYWarning("Taper selection not supported for time-frequency spectra!\nAbort plotting..")
-            return
+            SPYWarning("Taper selection not supported for time-frequency spectra! Aborting plotting.")
+            return None, None
 
         if not isinstance(label, str):
-            SPYWarning("Please select a single channel for plotting!\nAbort plotting..")
-            return
+            SPYWarning("Please select a single channel for plotting! Aborting plotting.")
+            return None, None
 
         # here we always need a new axes
         fig, ax = _plotting.mk_img_figax()
@@ -155,8 +156,8 @@ def plot_SpectralData(data, **show_kwargs):
             data_y = np.log10(data.show(**show_kwargs))
             ylabel = 'power (dB)'
         elif output in ['fourier', 'complex']:
-            SPYWarning("Can't plot complex valued spectra, choose 'real' or 'imag' as output!\nAbort plotting..")
-            return
+            SPYWarning("Can't plot complex valued spectra, choose 'real' or 'imag' as output. Aborting plotting.")
+            return None, None
         else:
             data_y = data.show(**show_kwargs)
             ylabel = f'{output}'
@@ -182,23 +183,28 @@ def plot_CrossSpectralData(data, **show_kwargs):
     ----------
     data : :class:`~syncopy.datatype.CrossSpectralData`
     show_kwargs : :func:`~syncopy.datatype.methods.show.show` arguments
+
+    Returns
+    -------
+    fig : `matplotlib.figure.Figure` instance (or `None` in case of errors), the plot figure.
+    ax  : `matplotlib.axes.Axes` instance (or `None` in case of errors), the plot axes.
     """
 
     if not __plt__:
         SPYWarning(pltErrMsg)
-        return
+        return None, None
 
     # right now we have to enforce
     # single trial selection only
     trl = show_kwargs.get('trials', 0)
     if not isinstance(trl, int) and len(data.trials) > 1:
-        SPYWarning("Please select a single trial for plotting!")
-        return
+        SPYWarning("Please select a single trial for plotting.")
+        return None, None
 
     # what channel combination
     if 'channel_i' not in show_kwargs or 'channel_j' not in show_kwargs:
-        SPYWarning("Please select a channel combination `channel_i` and `channel_j` for plotting!")
-        return
+        SPYWarning("Please select a channel combination `channel_i` and `channel_j` for plotting.")
+        return None, None
     chi, chj = show_kwargs['channel_i'], show_kwargs['channel_j']
     # parse labels
     if isinstance(chi, str):

--- a/syncopy/shared/const_def.py
+++ b/syncopy/shared/const_def.py
@@ -7,21 +7,29 @@
 import numpy as np
 from scipy.signal import windows
 
+
 # Module-wide output specs
 spectralDTypes = {"pow": np.float32,
+                  "abs": np.float32,
+                  "real": np.float32,
+                  "imag": np.float32,
+                  "angle": np.float32,
+                  "absreal": np.float32,
+                  "absimag": np.float32,
                   "fourier": np.complex64,
-                  "abs": np.float32}
+                  "complex": np.complex64
+                  }
 
 #: output conversion of complex fourier coefficients
 spectralConversions = {
-    'abs': lambda x: (np.absolute(x)).real.astype(np.float32),
-    'pow': lambda x: (x * np.conj(x)).real.astype(np.float32),
-    'fourier': lambda x: x.astype(np.complex64),
-    'real': lambda x: np.real(x),
-    'imag': lambda x: np.imag(x),
-    'angle': lambda x: np.angle(x),
-    'absreal': lambda x: np.abs(np.real(x)),
-    'absimag': lambda x: np.abs(np.imag(x)),
+    'pow': lambda x: (x * np.conj(x)).real.astype(spectralDTypes['pow']),
+    'abs': lambda x: (np.absolute(x)).real.astype(spectralDTypes['abs']),
+    'fourier': lambda x: x.astype(spectralDTypes['fourier']),
+    'real': lambda x: np.real(x).astype(spectralDTypes['real']),
+    'imag': lambda x: np.imag(x).astype(spectralDTypes['imag']),
+    'angle': lambda x: np.angle(x).astype(spectralDTypes['angle']),
+    'absreal': lambda x: np.abs(np.real(x)).astype(spectralDTypes['absreal']),
+    'absimag': lambda x: np.abs(np.imag(x)).astype(spectralDTypes['absimag'])
 }
 
 # FT compat

--- a/syncopy/shared/input_processors.py
+++ b/syncopy/shared/input_processors.py
@@ -27,7 +27,9 @@ def process_padding(pad, lenTrials, samplerate):
     padding has to be done **after** tapering!
 
     This function returns a number indicating the total
-    length in sample-count of all trials after padding.
+    length in samples of all trials after padding. When
+    inputted into fft related methods, the actual padding
+    is then performed there.
 
     Parameters
     ----------
@@ -291,6 +293,13 @@ def process_taper(taper,
         minBw = 2 * samplerate / nSamples
         # -----------------------------------
 
+        # --- maximal smoothing bandwidth ---
+        # --- such that Kmax < nSamples and NW < nSamples / 2
+        maxBw = np.min([samplerate / 2 - 1 / nSamples,
+                        samplerate * (nSamples + 1) / (2 * nSamples)])
+        # -----------------------------------
+        
+
         try:
             scalar_parser(tapsmofrq, varname="tapsmofrq", lims=[0, np.inf])
         except Exception:
@@ -302,10 +311,20 @@ def process_taper(taper,
             SPYInfo(msg)
             tapsmofrq = minBw
 
+        if tapsmofrq > maxBw:
+            msg = f'Setting tapsmofrq to the maximal attainable bandwidth of {maxBw:.2f}Hz'
+            SPYInfo(msg)
+            SPYInfo(msg)
+            tapsmofrq = maxBw
+            
         # --------------------------------------------------------------
         # set parameters for scipy.signal.windows.dpss
         NW, Kmax = _get_dpss_pars(tapsmofrq, nSamples, samplerate)
         # --------------------------------------------------------------
+        print(NW, Kmax)
+        
+        # tapsmofrq too large
+        # if Kmax > nSamples or NW > nSamples / 2:
 
         # the recommended way:
         # set nTaper automatically to achieve exact effective smoothing bandwidth

--- a/syncopy/shared/input_processors.py
+++ b/syncopy/shared/input_processors.py
@@ -314,7 +314,6 @@ def process_taper(taper,
         if tapsmofrq > maxBw:
             msg = f'Setting tapsmofrq to the maximal attainable bandwidth of {maxBw:.2f}Hz'
             SPYInfo(msg)
-            SPYInfo(msg)
             tapsmofrq = maxBw
             
         # --------------------------------------------------------------

--- a/syncopy/shared/input_processors.py
+++ b/syncopy/shared/input_processors.py
@@ -321,7 +321,6 @@ def process_taper(taper,
         # set parameters for scipy.signal.windows.dpss
         NW, Kmax = _get_dpss_pars(tapsmofrq, nSamples, samplerate)
         # --------------------------------------------------------------
-        print(NW, Kmax)
         
         # tapsmofrq too large
         # if Kmax > nSamples or NW > nSamples / 2:

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -527,7 +527,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
                                          samplerate=data.samplerate,
                                          nSamples=minSampleNum,
                                          output=output)
-
+        print(taper_opt)
         # Update `log_dct` w/method-specific options
         log_dct["taper"] = taper
         if taper_opt and taper == 'dpss':

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -527,7 +527,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
                                          samplerate=data.samplerate,
                                          nSamples=minSampleNum,
                                          output=output)
-        print(taper_opt)
+
         # Update `log_dct` w/method-specific options
         log_dct["taper"] = taper
         if taper_opt and taper == 'dpss':

--- a/syncopy/specest/mtmfft.py
+++ b/syncopy/specest/mtmfft.py
@@ -111,6 +111,7 @@ def _get_dpss_pars(tapsmofrq, nSamples, samplerate):
 
     """ Helper function to retrieve dpss parameters from tapsmofrq """
 
+    # taper width parameter in sample units
     NW = tapsmofrq * nSamples / samplerate
     # from the minBw setting NW always is at least 1
     Kmax = int(2 * NW - 1)  # optimal number of tapers

--- a/syncopy/tests/helpers.py
+++ b/syncopy/tests/helpers.py
@@ -13,7 +13,7 @@ import numpy as np
 from syncopy.shared.errors import SPYValueError, SPYTypeError
 
 # fix random generators
-np.random.seed(40203)
+test_seed = 42
 
 
 def run_padding_test(method_call, pad_length):
@@ -128,7 +128,7 @@ def mk_selection_dicts(nTrials, nChannels, toi_min, toi_max, min_len=0.25):
     """
     Takes 5 numbers, the last three descibing a `toilim/toi` time-interval
     and creates cartesian product like `select` keyword
-    arguments.
+    arguments. One random selection per toi/toilim is enough!
 
     Returns
     -------
@@ -143,9 +143,9 @@ def mk_selection_dicts(nTrials, nChannels, toi_min, toi_max, min_len=0.25):
     # at least 250ms
     assert (toi_max - toi_min) > 0.25
 
-    # create 3 random trial and channel selections
+    # create 1 random trial and channel selections
     trials, channels = [], []
-    for _ in range(3):
+    for _ in range(1):
 
         sizeTr = np.random.randint(10, nTrials + 1)
         trials.append(list(np.random.choice(
@@ -168,9 +168,9 @@ def mk_selection_dicts(nTrials, nChannels, toi_min, toi_max, min_len=0.25):
                                          channels,
                                          tois)
 
-    # 2 random toilims
+    # 1 random toilim
     toilims = []
-    while len(toilims) < 2:
+    while len(toilims) < 1:
 
         toil = np.sort(np.random.rand(2)) * (toi_max - toi_min) + toi_min
         # at least min_len (250ms)

--- a/syncopy/tests/test_plotting.py
+++ b/syncopy/tests/test_plotting.py
@@ -182,12 +182,12 @@ class TestSpectralPlotting():
             _, _ = self.spec_fft_imag.singlepanelplot(**kwargs)
             _, _ = self.spec_fft_imag.multipanelplot(**kwargs)
 
-            res = self.spec_fft_complex.singlepanelplot(**kwargs)
+            res, res2 = self.spec_fft_complex.singlepanelplot(**kwargs)
             # no plot of complex valued spectra
-            assert res is None
+            assert res is None and res2 is None
             res = self.spec_fft_complex.multipanelplot(**kwargs)
             assert res is None
-            
+
             fig3, ax2 = self.spec_wlet.singlepanelplot(channel=0, **kwargs)
             fig4, axs = self.spec_wlet.multipanelplot(**kwargs)
 

--- a/syncopy/tests/test_plotting.py
+++ b/syncopy/tests/test_plotting.py
@@ -156,6 +156,7 @@ class TestSpectralPlotting():
 
     spec_fft = spy.freqanalysis(adata, tapsmofrq=1)
     spec_fft_imag = spy.freqanalysis(adata, output='imag')
+    spec_fft_complex = spy.freqanalysis(adata, output='fourier')
 
     spec_wlet = spy.freqanalysis(adata, method='wavelet',
                                  foi=np.arange(0, 400, step=4))
@@ -181,6 +182,12 @@ class TestSpectralPlotting():
             _, _ = self.spec_fft_imag.singlepanelplot(**kwargs)
             _, _ = self.spec_fft_imag.multipanelplot(**kwargs)
 
+            res = self.spec_fft_complex.singlepanelplot(**kwargs)
+            # no plot of complex valued spectra
+            assert res is None
+            res = self.spec_fft_complex.multipanelplot(**kwargs)
+            assert res is None
+            
             fig3, ax2 = self.spec_wlet.singlepanelplot(channel=0, **kwargs)
             fig4, axs = self.spec_wlet.multipanelplot(**kwargs)
 

--- a/syncopy/tests/test_plotting.py
+++ b/syncopy/tests/test_plotting.py
@@ -202,7 +202,7 @@ class TestSpectralPlotting():
             # take the 1st random channel for 2d spectra
             if 'channel' in kwargs:
                 chan = kwargs.pop('channel')[0]
-            self.spec_wlet.singlepanelplot(channel=chan, **kwargs)
+                self.spec_wlet.singlepanelplot(channel=chan, **kwargs)
             ppl.close('all')
 
     def test_spectral_selections(self):
@@ -257,6 +257,14 @@ class TestSpectralPlotting():
             self.test_spectral_plotting(trials=0, foi=[-1, 0])
             assert "foi/foilim" in str(err)
             assert "bounded by" in str(err)
+
+    def test_spectral_warnings(self, capsys):
+
+        # Invalid trial selection: several trials selected (and available)
+        #  with spectral plotting.
+        self.test_spectral_plotting(trials=[0, 1])
+        captured = capsys.readouterr()
+        assert "select a single trial for" in captured.out
 
 
 class TestCrossSpectralPlotting():

--- a/syncopy/tests/test_plotting.py
+++ b/syncopy/tests/test_plotting.py
@@ -23,12 +23,14 @@ class TestAnalogPlotting():
     nSamples = 300
     adata = synth_data.AR2_network(nTrials=nTrials,
                                    AdjMat=np.zeros(nChannels),
-                                   nSamples=nSamples)
+                                   nSamples=nSamples,
+                                   seed=helpers.test_seed)
 
     adata += 0.3 * synth_data.linear_trend(nTrials=nTrials,
                                            y_max=nSamples / 20,
                                            nSamples=nSamples,
                                            nChannels=nChannels)
+
 
     # add an offset
     adata = adata + 5
@@ -105,6 +107,18 @@ class TestAnalogPlotting():
             self.test_ad_plotting(trials=self.nTrials + 1)
             assert "select: trials" in str(err)
 
+    def test_ad_dimord(self):
+        # create new mockup data
+        rng = np.random.default_rng(helpers.test_seed)
+        nSamples = 100
+        nChannels = 4
+        # single trial with ('channel', 'time') dimord
+        ad = spy.AnalogData([rng.standard_normal((nChannels, nSamples))], dimord=['channel', 'time'])
+        for chan in ad.channel:
+            fig, ax = ad.singlepanelplot(channel=chan)
+        # check that the right axis is the time axis
+        xleft, xright = ax.get_xlim()
+        assert xright - xleft >= nSamples / ad.samplerate
 
 class TestSpectralPlotting():
 

--- a/syncopy/tests/test_plotting.py
+++ b/syncopy/tests/test_plotting.py
@@ -155,6 +155,8 @@ class TestSpectralPlotting():
     toi_min, toi_max = adata.time[0][0], adata.time[0][-1]
 
     spec_fft = spy.freqanalysis(adata, tapsmofrq=1)
+    spec_fft_imag = spy.freqanalysis(adata, output='imag')
+
     spec_wlet = spy.freqanalysis(adata, method='wavelet',
                                  foi=np.arange(0, 400, step=4))
 
@@ -175,6 +177,9 @@ class TestSpectralPlotting():
             # this simulates the interactive plotting
             fig1, ax1 = self.spec_fft.singlepanelplot(**kwargs)
             fig2, axs = self.spec_fft.multipanelplot(**kwargs)
+
+            _, _ = self.spec_fft_imag.singlepanelplot(**kwargs)
+            _, _ = self.spec_fft_imag.multipanelplot(**kwargs)
 
             fig3, ax2 = self.spec_wlet.singlepanelplot(channel=0, **kwargs)
             fig4, axs = self.spec_wlet.multipanelplot(**kwargs)
@@ -273,6 +278,8 @@ class TestCrossSpectralPlotting():
     toi_min, toi_max = adata.time[0][0], adata.time[0][-1]
 
     coh = spy.connectivityanalysis(adata, method='coh', tapsmofrq=1)
+    coh_imag = spy.connectivityanalysis(adata, method='coh', tapsmofrq=1, output='imag')
+
     corr = spy.connectivityanalysis(adata, method='corr')
     granger = spy.connectivityanalysis(adata, method='granger', tapsmofrq=1)
 
@@ -290,6 +297,8 @@ class TestCrossSpectralPlotting():
             self.coh.singlepanelplot(channel_i=0, channel_j=1, foilim=[50, 320])
             self.coh.singlepanelplot(channel_i=1, channel_j=2, foilim=[50, 320])
             self.coh.singlepanelplot(channel_i=2, channel_j=3, foilim=[50, 320])
+
+            self.coh_imag.singlepanelplot(channel_i=1, channel_j=2, foilim=[50, 320])
 
             self.corr.singlepanelplot(channel_i=0, channel_j=1, toilim=[0, .1])
             self.corr.singlepanelplot(channel_i=1, channel_j=0, toilim=[0, .1])

--- a/syncopy/tests/test_plotting.py
+++ b/syncopy/tests/test_plotting.py
@@ -205,13 +205,6 @@ class TestSpectralPlotting():
                 self.spec_wlet.singlepanelplot(channel=chan, **kwargs)
             ppl.close('all')
 
-    def test_spectral_warnings(self, capsys):
-        # Invalid: taper
-        res1, res2 = self.spec_wlet.singlepanelplot(channel=0, taper=0)
-        captured = capsys.readouterr()
-        assert "select a single trial for" in captured.out
-        assert res1 is None and res2 is None
-
     def test_spectral_selections(self):
 
         # trial, channel and toi selections
@@ -264,15 +257,6 @@ class TestSpectralPlotting():
             self.test_spectral_plotting(trials=0, foi=[-1, 0])
             assert "foi/foilim" in str(err)
             assert "bounded by" in str(err)
-
-    def test_spectral_warnings(self, capsys):
-
-        # Invalid trial selection: several trials selected (and available)
-        #  with spectral plotting.
-        self.test_spectral_plotting(trials=[0, 1])
-        captured = capsys.readouterr()
-        assert "select a single trial for" in captured.out
-
 
 class TestCrossSpectralPlotting():
 

--- a/syncopy/tests/test_plotting.py
+++ b/syncopy/tests/test_plotting.py
@@ -114,11 +114,23 @@ class TestAnalogPlotting():
         nChannels = 4
         # single trial with ('channel', 'time') dimord
         ad = spy.AnalogData([rng.standard_normal((nChannels, nSamples))], dimord=['channel', 'time'])
+
         for chan in ad.channel:
             fig, ax = ad.singlepanelplot(channel=chan)
         # check that the right axis is the time axis
         xleft, xright = ax.get_xlim()
         assert xright - xleft >= nSamples / ad.samplerate
+
+        # test multipanelplot
+        fig, axs = ad.multipanelplot()
+        # check that we have indeed nChannels axes
+        assert axs.size == nChannels
+
+        xleft, xright = axs[0,0].get_xlim()
+        # check that the right axis is the time axis
+        xleft, xright = ax.get_xlim()
+        assert xright - xleft >= nSamples / ad.samplerate
+
 
 class TestSpectralPlotting():
 

--- a/syncopy/tests/test_plotting.py
+++ b/syncopy/tests/test_plotting.py
@@ -205,6 +205,13 @@ class TestSpectralPlotting():
                 self.spec_wlet.singlepanelplot(channel=chan, **kwargs)
             ppl.close('all')
 
+    def test_spectral_warnings(self, capsys):
+        # Invalid: taper
+        res1, res2 = self.spec_wlet.singlepanelplot(channel=0, taper=0)
+        captured = capsys.readouterr()
+        assert "select a single trial for" in captured.out
+        assert res1 is None and res2 is None
+
     def test_spectral_selections(self):
 
         # trial, channel and toi selections

--- a/syncopy/tests/test_specest.py
+++ b/syncopy/tests/test_specest.py
@@ -239,13 +239,18 @@ class TestMTMFFT():
                                 tapsmofrq=7, keeptapers=True, select=select)
             assert spec.channel.size == len(chanList)
 
+            # trigger capture of too large tapsmofrq (edge case)
+            spec = freqanalysis(self.adata, method="mtmfft",
+                                tapsmofrq=3000, output="pow", select=select)
+            
+
         # non-equidistant data w/multiple tapers
         artdata = generate_artificial_data(nTrials=5, nChannels=16,
                                            equidistant=False, inmemory=False)
         timeAxis = artdata.dimord.index("time")
         cfg = StructDict()
         cfg.method = "mtmfft"
-        cfg.tapsmofrq = 9.3
+        cfg.tapsmofrq = 3.3
         cfg.output = "pow"
 
         for select in self.artdataSelections:


### PR DESCRIPTION
This PR actually addreses a bunch of minor bugs, that appeared during manual testing:

- `spectralDTypes` in `shared.const_def` now contain all supported outputs
- multi-taper parameters now are aware of the maximal smoothing bw possible (edge case)
- fixed dimord for AnalogData, for other datatypes it is most likely not needed, as the frontend results always have the default dimord (how would you get a `SpectralData` with non-default dimord? ..we don't support reading FT spectral data atm anyways)
- now for `output != 'pow'` there is no general log10, so imaginary/real parts of spectra/coherence can also be plotted nicely (they of course can have negative values)
- cut back on the test helper selection generation, one random combination per toi/toilim setting is enough 
- also addressed #357, I hope there are no undesired side effects.. tests are not complaining though

Author Guidelines
-----------------
- [x] Is the change set **< 600 lines**?
- [x] Was the code checked for memory leaks/performance bottlenecks?
- [x] Is the code running locally **and** on the ESI cluster?
- [x] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do **parallel** loops have a set length and correct termination conditions?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [x] Code layout
  - [x] Is the code PEP8 compliant?
  - [x] Does the code adhere to agreed-upon naming conventions?
  - [x] Are keywords clearly named and easy to understand?
  - [x] No commented-out code?
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
