### PR TITLE
364 rewire connectivity analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - Added additional .info entries for Granger analysis, indicating details about the computation.
 - Added additional .info entries for FoooF results, e.g. Gaussian fit parameters.
 - Fix bug #365, plotting supports custom dimords now.
+- Support starting a connectivity analysis from a SpectralData instance (#364).
 
 ### CHANGED
 - Maximal brute force regularization parameter for Granger increased to 1e-1

--- a/syncopy/nwanalysis/ST_compRoutines.py
+++ b/syncopy/nwanalysis/ST_compRoutines.py
@@ -108,12 +108,12 @@ class SpectralDyadicProduct(ComputationalRoutine):
     syncopy.connectivityanalysis : parent metafunction
     """
 
-    # the hard wired dimord of the cF
+    # The hard wired dimord of the cF
     dimord = ['time', 'freq', 'channel_i', 'channel_j']
 
     computeFunction = staticmethod(spectral_dyadic_product_cF)
 
-    # 1st argument,the data, gets omitted
+    # 1st argument, the data, gets omitted.
     valid_kws = list(signature(spectral_dyadic_product_cF).parameters.keys())[1:]
     valid_kws += ['output']
 
@@ -149,16 +149,16 @@ def cross_spectra_cF(trl_dat,
     elements on the main diagonal (`CS_ii`) are the (real) auto-spectra.
 
     This is NOT the same as what is commonly referred to as
-    "cross spectral density" as there is no (time) averaging!!
+    "cross spectral density" as there is no (time) averaging!
     Multi-tapering alone is not necessarily sufficient to get enough
-    statitstical power for a robust csd estimate. Yet for completeness
-    and testing the option `norm=True` will output a single-trial
+    statistical power for a robust csd estimate. Still, for completeness
+    and testing the option `norm=True`, this function does output a single-trial
     coherence estimate.
 
     Parameters
     ----------
     trl_dat : (K, N) :class:`numpy.ndarray`
-        Uniformly sampled multi-channel time-series data
+        Uniformly sampled multi-channel time-series data.
         The 1st dimension is interpreted as the time axis,
         columns represent individual channels.
         Dimensions can be transposed to `(N, K)` with the `timeAxis` parameter.
@@ -172,7 +172,7 @@ def cross_spectra_cF(trl_dat,
         cannot be matched exactly the closest possible frequencies (respecting
         data length and padding) are used.
     taper : str or None
-        Taper function to use, one of scipy.signal.windows
+        Taper function to use, one of `scipy.signal.windows`.
         Set to `None` for no tapering.
     taper_opt : dict, optional
         Additional keyword arguments passed to the `taper` function.
@@ -275,9 +275,9 @@ class CrossSpectra(ComputationalRoutine):
 
     """
     Compute class that calculates single-trial (multi-)tapered cross spectra
-    of :class:`~syncopy.AnalogData` objects
+    of :class:`~syncopy.AnalogData` objects.
     For coherence computation, `keeptrials` is set to `False` to right away
-    average the single-trial cross-spectra
+    average the single-trial cross-spectra.
 
     Sub-class of :class:`~syncopy.shared.computational_routine.ComputationalRoutine`,
     see :doc:`/developer/compute_kernels` for technical details on Syncopy's compute

--- a/syncopy/nwanalysis/ST_compRoutines.py
+++ b/syncopy/nwanalysis/ST_compRoutines.py
@@ -82,7 +82,7 @@ def spectral_dyadic_product_cF(trl_dat,
     specs = trl_dat[0, ...]
     # dyadic product along channel axes
     # result has shape (nTapers x nFreq x nChannels x nChannels)
-    CS_ij = specs[:, :, np.newaxis, :] * specs[:, :, :, np.newaxis].conj()
+    CS_ij = specs[:, :, :, np.newaxis] * specs[:, :, np.newaxis, :].conj()
 
     # now average tapers and attach dummy time axis
     # result has shape (1 x nFreq x nChannels x nChannels)
@@ -115,6 +115,7 @@ class SpectralDyadicProduct(ComputationalRoutine):
 
     # 1st argument,the data, gets omitted
     valid_kws = list(signature(spectral_dyadic_product_cF).parameters.keys())[1:]
+    valid_kws += ['output']
 
     def process_metadata(self, data, out):
 
@@ -295,7 +296,7 @@ class CrossSpectra(ComputationalRoutine):
     # 1st argument,the data, gets omitted
     valid_kws = list(signature(cross_spectra_cF).parameters.keys())[1:]
     # hardcode some parameter names which got digested from the frontend
-    valid_kws += ['tapsmofrq', 'nTaper', 'pad']
+    valid_kws += ['tapsmofrq', 'nTaper', 'pad', 'output']
 
     def process_metadata(self, data, out):
 

--- a/syncopy/nwanalysis/ST_compRoutines.py
+++ b/syncopy/nwanalysis/ST_compRoutines.py
@@ -23,6 +23,105 @@ from syncopy.shared.kwarg_decorators import process_io
 
 
 @process_io
+def spectral_dyadic_product_cF(trl_dat,
+                               chunkShape=None,
+                               noCompute=False):
+    """
+    Single trial cross spectra directly from power spectra,
+    hence no Fourier transforms are needed and all what is
+    left to do is to take the outer product along the channel axis.
+
+    In case the spectral input has a taper axis, those get averaged
+    out after the cross products are calculated.
+
+    Parameters
+    ----------
+    trl_dat: (K, N) :class:`numpy.ndarray`
+        Complex and frequency aligned multi-channel spectral data.
+        The 1st dimension is interpreted as the frequency axis,
+        `N` columns represent individual channels.
+    noCompute : bool
+        Preprocessing flag. If `True`, do not perform actual calculation but
+        instead return expected shape and :class:`numpy.dtype` of output
+        array.
+
+    Returns
+    -------
+    CS_ij : (1, len(K), N, N) :class:`numpy.ndarray`
+        Complex cross spectra for all channel combinations ``i,j``.
+        `N` corresponds to number of input channels.
+
+    Notes
+    -----
+    This method is intended to be used as
+    :meth:`~syncopy.shared.computational_routine.ComputationalRoutine.computeFunction`
+    inside a :class:`~syncopy.shared.computational_routine.ComputationalRoutine`.
+    Thus, input parameters are presumed to be forwarded from a parent metafunction.
+    Consequently, this function does **not** perform any error checking and operates
+    under the assumption that all inputs have been externally validated and cross-checked.
+
+    See also
+    --------
+    normalize_csd : :func:`~syncopy.connectivity.csd.normalize_csd`
+             Coherence from trial averages
+
+    """
+
+    # default dimord for SpectralData is ['time', 'taper', 'freq', 'channel']
+    nFreq = trl_dat.shape[2]
+    nChannels = trl_dat.shape[3]
+
+    # we always average over tapers here
+    outShape = (1, nFreq, nChannels, nChannels)
+
+    # cross spectra are complex, input gets checked in frontend!
+    if noCompute:
+        return outShape, spectralDTypes["fourier"]
+
+    # split off empty time axis, shape is now (nTapers, nFreq, nChannel)
+    specs = trl_dat[0, ...]
+    # dyadic product along channel axes
+    # result has shape (nTapers x nFreq x nChannels x nChannels)
+    CS_ij = specs[:, :, np.newaxis, :] * specs[:, :, :, np.newaxis].conj()
+
+    # now average tapers and attach dummy time axis
+    # result has shape (1 x nFreq x nChannels x nChannels)
+    CS_ij = CS_ij.mean(axis=0)[np.newaxis, ...]
+    return CS_ij
+
+
+class SpectralDyadicProduct(ComputationalRoutine):
+
+    """
+    Compute class that calculates single-trial cross spectra
+    from :class:`~syncopy.SpectralData` objects, which in the end
+    is just the dyadic (outer) product between channels.
+    For coherence computation, `keeptrials` is set to `False` to right away
+    average the single-trial cross-spectra
+
+    Sub-class of :class:`~syncopy.shared.computational_routine.ComputationalRoutine`,
+    see :doc:`/developer/compute_kernels` for technical details on Syncopy's compute
+    classes and metafunctions.
+
+    See also
+    --------
+    syncopy.connectivityanalysis : parent metafunction
+    """
+
+    # the hard wired dimord of the cF
+    dimord = ['time', 'freq', 'channel_i', 'channel_j']
+
+    computeFunction = staticmethod(spectral_dyadic_product_cF)
+
+    # 1st argument,the data, gets omitted
+    valid_kws = list(signature(spectral_dyadic_product_cF).parameters.keys())[1:]
+
+    def process_metadata(self, data, out):
+
+        propagate_properties(data, out, self.keeptrials)
+
+
+@process_io
 def cross_spectra_cF(trl_dat,
                      samplerate=1,
                      nSamples=None,
@@ -168,10 +267,10 @@ def cross_spectra_cF(trl_dat,
     freqs_hash = blake2b(freqs).hexdigest().encode('utf-8')
     metadata = {'freqs_hash': np.array(freqs_hash)}  # Will have dtype='|S128'
 
-    return CS_ij[None, freq_idx, ...], metadata
+    return CS_ij[np.newaxis, freq_idx, ...], metadata
 
 
-class ST_CrossSpectra(ComputationalRoutine):
+class CrossSpectra(ComputationalRoutine):
 
     """
     Compute class that calculates single-trial (multi-)tapered cross spectra
@@ -196,7 +295,7 @@ class ST_CrossSpectra(ComputationalRoutine):
     # 1st argument,the data, gets omitted
     valid_kws = list(signature(cross_spectra_cF).parameters.keys())[1:]
     # hardcode some parameter names which got digested from the frontend
-    valid_kws += ['tapsmofrq', 'nTaper', 'pad_to_length']
+    valid_kws += ['tapsmofrq', 'nTaper', 'pad']
 
     def process_metadata(self, data, out):
 
@@ -329,7 +428,7 @@ def cross_covariance_cF(trl_dat,
         return CC, lags
 
 
-class ST_CrossCovariance(ComputationalRoutine):
+class CrossCovariance(ComputationalRoutine):
 
     """
     Compute class that calculates single-trial cross-covariances

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -394,10 +394,6 @@ def cross_spectra(data, method, nSamples,
 
     foi, foilim = process_foi(foi, foilim, data.samplerate)
 
-    # only now set foi array for foilim in 1Hz steps
-    if foilim is not None:
-        foi = np.arange(foilim[0], foilim[1] + 1, dtype=float)
-
     # --- Setting up specific Methods ---
     if method == 'granger':
 

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -308,9 +308,9 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         elif isinstance(data, SpectralData):
 
             # cross-spectra need complex input spectra
-            if data.cfg['freqanalysis']['output'] != 'fourier':
-                lgl = "`output='fourier'` in previous spectral analysis"
-                act = f"{data.cfg['freqanalysis']['output']} spectra"
+            if data.data.dtype != np.complex64 and data.data.dtype != np.complex128:
+                lgl = "complex valued spectra, set `output='fourier` in spy.freqanalysis!"
+                act = f"real valued spectral data"
                 raise SPYValueError(lgl, 'data', act)
 
             # by constraining to output='fourier', detrimental taper averaging

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -37,7 +37,7 @@ coh_outputs = {"abs", "pow", "complex", "fourier", "angle", "real", "imag"}
 @detect_parallel_client
 def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                          foi=None, foilim=None, pad='maxperlen',
-                         polyremoval=None, tapsmofrq=None, nTaper=None,
+                         polyremoval=0, tapsmofrq=None, nTaper=None,
                          taper="hann", taper_opt=None, **kwargs):
 
     """
@@ -330,6 +330,11 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         av_compRoutine = NormalizeCrossSpectra(output=output)
 
     if method == 'granger':
+
+        # spectral analysis only possible with AnalogData
+        besides = ['tapsmofrq'] if isinstance(data, AnalogData) else None
+        check_effective_parameters(GrangerCausality, defaults, lcls, besides=besides)
+
         # after trial averaging
         # hardcoded numerical parameters
         av_compRoutine = GrangerCausality(rtol=1e-6,
@@ -402,7 +407,7 @@ def cross_spectra(data, method, nSamples,
             raise SPYValueError(lgl, 'foi/foilim', actual)
 
         nChannels = len(data.channel)
-        nTrials = len(lenTrials)
+        nTrials = len(data.trials)
         # warn user if this ratio is not small
         if nChannels / nTrials > 0.1:
             msg = "Multi-channel Granger analysis can be numerically unstable, it is recommended to have at least 10 times the number of trials compared to the number of channels. Try calculating in sub-groups of fewer channels!"
@@ -450,13 +455,13 @@ def cross_spectra(data, method, nSamples,
 
         # parallel computation over trials
         st_compRoutine = CrossSpectra(samplerate=data.samplerate,
-                                         nSamples=nSamples,
-                                         taper=taper,
-                                         taper_opt=taper_opt,
-                                         demean_taper=method == 'granger',
-                                         polyremoval=polyremoval,
-                                         timeAxis=timeAxis,
-                                         foi=foi)
+                                      nSamples=nSamples,
+                                      taper=taper,
+                                      taper_opt=taper_opt,
+                                      demean_taper=method == 'granger',
+                                      polyremoval=polyremoval,
+                                      timeAxis=timeAxis,
+                                      foi=foi)
         # hard coded as class attribute
         st_dimord = CrossSpectra.dimord
 

--- a/syncopy/nwanalysis/connectivity_analysis.py
+++ b/syncopy/nwanalysis/connectivity_analysis.py
@@ -195,7 +195,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
     if not isinstance(data, (AnalogData, SpectralData)):
         lgl = "either AnalogData or SpectralData as input"
         act = f"{data.__class__.__name__}"
-        raise SPYValueError(lgg, 'data', act)
+        raise SPYValueError(lgl, 'data', act)
     timeAxis = data.dimord.index("time")
 
     # check that for SpectralData input, we have empty time axes

--- a/syncopy/nwanalysis/csd.py
+++ b/syncopy/nwanalysis/csd.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# computeFunctions and -Routines for parallel calculation
-# of single trial measures needed for the averaged
-# measures like cross spectral densities
+# Backend functions for calculating cross spectral densities
+#
 #
 
 # Builtin/3rd party package imports

--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -1074,7 +1074,7 @@ def propagate_properties(in_data, out_data, keeptrials=True):
         out_data.samplerate = in_data.samplerate
 
     # this is for (cross-) spectral data with empty time axis (MultiTaperFFT / CSD)
-    elif is_Analog(in_data) and (is_Spectral(out_data) or is_CrossSpectral(out_data)):
+    elif (is_Analog(in_data) or is_Spectral(in_data)) and (is_Spectral(out_data) or is_CrossSpectral(out_data)):
 
         # Some index gymnastics to get trial begin/end "samples"
         if in_data.selection is not None:
@@ -1107,6 +1107,10 @@ def propagate_properties(in_data, out_data, keeptrials=True):
         elif is_CrossSpectral(out_data):
             out_data.channel_i = np.array(in_data.channel[chanSec])
             out_data.channel_j = np.array(in_data.channel[chanSec])
+
+        # no further foi manipulation after original freqanalysis!
+        if is_Spectral(in_data):
+            out_data.freq = in_data.freq
 
     # for the AV_compRoutines
     elif is_CrossSpectral(in_data) and is_CrossSpectral(out_data):

--- a/syncopy/shared/const_def.py
+++ b/syncopy/shared/const_def.py
@@ -38,5 +38,5 @@ availableTapers = all_windows
 availablePaddingOpt = ['maxperlen', 'nextpow2']
 
 #: general, method agnostic, parameters for our CRs
-generalParameters = ("method", "output", "keeptrials", "samplerate",
-                     "foi", "foilim", "polyremoval", "out", "pad_to_length")
+generalParameters = ("method", "keeptrials", "samplerate",
+                     "foi", "foilim", "polyremoval", "out", "pad")

--- a/syncopy/shared/input_processors.py
+++ b/syncopy/shared/input_processors.py
@@ -283,8 +283,9 @@ def process_taper(taper,
 
         # direct mtm estimate (averaging) only valid for spectral power
         if not keeptapers and output != "pow":
-            lgl = "'pow', the only valid option for taper averaging"
-            raise SPYValueError(legal=lgl, varname="output", actual=output)
+            lgl = (f"'pow'|False or 'fourier'|True, taper averaging with"
+                   "`keeptapers=False` only possible with `output='pow'`!")
+            raise SPYValueError(legal=lgl, varname="output|keeptapers", actual=f"'{output}'|{keeptapers}")
 
         # --- minimal smoothing bandwidth ---
         # --- such that Kmax/nTaper is at least 1

--- a/syncopy/shared/input_processors.py
+++ b/syncopy/shared/input_processors.py
@@ -283,8 +283,8 @@ def process_taper(taper,
 
         # direct mtm estimate (averaging) only valid for spectral power
         if not keeptapers and output != "pow":
-            lgl = (f"'pow'|False or 'fourier'|True, taper averaging with"
-                   "`keeptapers=False` only possible with `output='pow'`!")
+            lgl = (f"'pow'|False or '{output}'|True, set keeptapers=True"
+                   "OR `output='pow'`!")
             raise SPYValueError(legal=lgl, varname="output|keeptapers", actual=f"'{output}'|{keeptapers}")
 
         # --- minimal smoothing bandwidth ---

--- a/syncopy/shared/input_processors.py
+++ b/syncopy/shared/input_processors.py
@@ -362,7 +362,7 @@ def check_effective_parameters(CR, defaults, lcls, besides=None):
 
     for name in relevant:
         if name not in expected and (lcls[name] != defaults[name]):
-            msg = f"option `{name}` has no effect in method `{CR.__name__}`!"
+            msg = f"option `{name}` has no effect for `{CR.__name__}`!"
             SPYWarning(msg, caller=__name__.split('.')[-1])
 
 

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -558,7 +558,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
             timeAxis=timeAxis,
             keeptapers=keeptapers,
             polyremoval=polyremoval,
-            output_fmt=output,
+            output=output,
             method_kwargs=method_kwargs)
 
     elif method == "mtmconvol":
@@ -698,7 +698,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
             timeAxis=timeAxis,
             keeptapers=keeptapers,
             polyremoval=polyremoval,
-            output_fmt=output,
+            output=output,
             method_kwargs=method_kwargs)
 
     elif method == "wavelet":
@@ -783,7 +783,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
             toi=toi,
             timeAxis=timeAxis,
             polyremoval=polyremoval,
-            output_fmt=output,
+            output=output,
             method_kwargs=method_kwargs)
 
     elif method == "superlet":
@@ -862,7 +862,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
             toi=toi,
             timeAxis=timeAxis,
             polyremoval=polyremoval,
-            output_fmt=output,
+            output=output,
             method_kwargs=method_kwargs)
 
     # -------------------------------------------------
@@ -906,12 +906,12 @@ def freqanalysis(data, method='mtmfft', output='pow',
             raise SPYValueError(legal="a frequency range that does not include zero. Use 'foi' or 'foilim' to restrict.", varname="foi/foilim", actual="Frequency range from {} to {}.".format(min(fooof_data.freq), max(fooof_data.freq)))
 
         # Set up compute-class
-        #  - the output_fmt must be one of 'fooof', 'fooof_aperiodic',
+        #  - the output must be one of 'fooof', 'fooof_aperiodic',
         #    or 'fooof_peaks'.
         #  - everything passed as method_kwargs is passed as arguments
         #    to the fooof.FOOOF() constructor or functions, the other args are
         #    used elsewhere.
-        fooofMethod = FooofSpy(output_fmt=output_fooof, fooof_settings=fooof_settings, method_kwargs=fooof_kwargs)
+        fooofMethod = FooofSpy(output=output_fooof, fooof_settings=fooof_settings, method_kwargs=fooof_kwargs)
 
         # Update `log_dct` w/method-specific options
         log_dct["fooof_method"] = output_fooof

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -51,7 +51,7 @@ availableMethods = ("mtmfft", "mtmconvol", "wavelet", "superlet")
 @detect_parallel_client
 def freqanalysis(data, method='mtmfft', output='pow',
                  keeptrials=True, foi=None, foilim=None,
-                 pad='maxperlen', polyremoval=0, taper="hann",
+                 pad='maxperlen', polyremoval=0, taper="hann", demean_taper=False,
                  taper_opt=None, tapsmofrq=None, nTaper=None, keeptapers=False,
                  toi="all", t_ftimwin=None, wavelet="Morlet", width=6, order=None,
                  order_max=None, order_min=1, c_1=3, adaptive=False,
@@ -185,9 +185,12 @@ def freqanalysis(data, method='mtmfft', output='pow',
         Number of orthogonal tapers to use for multi-tapering. It is not recommended to set the number
         of tapers manually! Leave at `None` for the optimal number to be set automatically.
     taper : str or None, optional
-        Only valid if `method` is `'mtmfft'` or `'mtmconvol'`. Windowing function,
+        Only valid if ``method`` is ``'mtmfft'`` or ``'mtmconvol'``. Windowing function,
         one of :data:`~syncopy.shared.const_def.availableTapers`
         For multi-tapering with slepian tapers use `tapsmofrq` directly.
+    demean_taper : bool
+        Set to `True` to perform de-meaning after tapering. Recommended for later Granger
+        analysis with :func:`~syncopy.connectivityanalysis`. Only valid for ``method='mtmfft'``.
     taper_opt : dict or None
         Dictionary with keys for additional taper parameters.
         For example :func:`~scipy.signal.windows.kaiser` has
@@ -344,7 +347,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
         raise SPYValueError(legal=lgl, varname="output", actual=output)
 
     # Parse all Boolean keyword arguments
-    for vname in ["keeptrials", "keeptapers"]:
+    for vname in ["keeptrials", "keeptapers", "demean_taper"]:
         if not isinstance(lcls[vname], bool):
             raise SPYTypeError(lcls[vname], varname=vname, expected="Bool")
 
@@ -549,7 +552,8 @@ def freqanalysis(data, method='mtmfft', output='pow',
             'samplerate': data.samplerate,
             'taper': taper,
             'taper_opt': taper_opt,
-            'nSamples': minSampleNum
+            'nSamples': minSampleNum,
+            'demean_taper': demean_taper
         }
 
         # Set up compute-class

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -43,7 +43,7 @@ class TestSpectralInput:
     ad = AnalogData([np.ones((5, 10)) for _ in range(2)], samplerate=200)
 
     def test_spectral_output(self):
-        for wrong_output in ['pow', 'abs']:  # add once #365 got merged, 'imag', 'real']:
+        for wrong_output in ['pow', 'abs', 'imag', 'real']:
             spec = spy.freqanalysis(self.ad, output=wrong_output)
 
             with pytest.raises(SPYValueError) as err:

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -48,11 +48,11 @@ class TestSpectralInput:
 
             with pytest.raises(SPYValueError) as err:
                 cafunc(spec, method='granger')
-            assert "expected `output='fourier'`" in str(err.value)
+            assert "expected complex valued" in str(err.value)
 
             with pytest.raises(SPYValueError) as err:
                 cafunc(spec, method='coh')
-            assert "expected `output='fourier'`" in str(err.value)
+            assert "expected complex valued" in str(err.value)
 
     def test_spectral_multitaper(self):
 

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -87,7 +87,6 @@ class TestSpectralInput:
             cafunc(spec, method='coh')
         assert "expected line spectra" in str(err.value)
 
-
 class TestGranger:
 
     nTrials = 150
@@ -125,6 +124,15 @@ class TestGranger:
     # better for granger
     cfg.demean_taper = True
     spec = spy.freqanalysis(data, cfg, output='fourier', keeptapers=True)
+
+    def test_spec_input_frontend(self):
+        assert isinstance(self.spec, SpectralData)
+        cfg = self.cfg.copy()
+        cfg.pop("demean_taper", None)
+        cfg.pop("tapsmofrq", None)
+        res = spy.connectivityanalysis(self.spec, method='granger', cfg=cfg)
+        assert isinstance(res, spy.CrossSpectralData)
+
 
     def test_gr_solution(self, **kwargs):
 


### PR DESCRIPTION
Addresses #364 , such that users can fine-tune and post-process `SpectralData` before inputting into `connectivityanalysis`. The old way of directly inputting `AnalogData` was preserved.

Author Guidelines
-----------------
- [x] Is the change set **< 600 lines**?
- [x] Was the code checked for memory leaks/performance bottlenecks?
- [x] Is the code running locally **and** on the ESI cluster?
- [x] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do **parallel** loops have a set length and correct termination conditions?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [x] Code layout
  - [x] Is the code PEP8 compliant?
  - [x] Does the code adhere to agreed-upon naming conventions?
  - [x] Are keywords clearly named and easy to understand?
  - [x] No commented-out code?
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
