### PR TITLE
Quick fix: spyvalueerrors

### DIFF
--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -192,7 +192,7 @@ class BaseData(ABC):
             setattr(self, "_" + propertyName, None)
         else:
             if not isinstance(inData, np.ndarray):
-                raise SPYValueError(lgl="object of type 'np.ndarray' or None", varname="inData")
+                raise SPYValueError(legal="object of type 'np.ndarray' or None", varname="inData")
             self._set_dataset_property_with_ndarray(inData, propertyName, inData.ndim)
 
     def _unregister_seq_dataset(self, propertyName, del_from_file=True):
@@ -372,7 +372,7 @@ class BaseData(ABC):
 
             if propertyName not in self._hdfFileDatasetProperties:
                 if getattr(self, "_" + propertyName) is not None and not isinstance(getattr(self, "_" + propertyName), h5py.Dataset):
-                    raise SPYValueError(lgl="propertyName that does not clash with existing attributes",
+                    raise SPYValueError(legal="propertyName that does not clash with existing attributes",
                                         varname=propertyName, actual=propertyName)
 
             h5f = self._get_backing_hdf5_file_handle()


### PR DESCRIPTION
This fixes 2 bugs I discovered when playing around with attaching datasets earlier: 2x wrong parameter name when constructing `SpyValueError`.

Coverage is really broken.

Author Guidelines
-----------------
- [x] Is the change set **< 600 lines**?
- [x] Was the code checked for memory leaks/performance bottlenecks?
- [x] Is the code running locally **and** on the ESI cluster?
- [x] Is the code running on all supported platforms?

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do **parallel** loops have a set length and correct termination conditions?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Do code-blocks provide novel functionality, i.e., no re-factoring using builtin/external packages possible?
- [ ] Code layout
  - [ ] Is the code PEP8 compliant?
  - [ ] Does the code adhere to agreed-upon naming conventions?
  - [ ] Are keywords clearly named and easy to understand?
  - [ ] No commented-out code?
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
