### PR TITLE
408 check out contiguous channel property for discrete data

### DIFF
--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -57,7 +57,7 @@ class DiscreteData(BaseData, ABC):
 
         if inData is not None:
             # probably not the most elegant way..
-            if not 'int' in str(self.data.dtype):
+            if 'int' not in str(self.data.dtype):
                 raise SPYTypeError(self.data.dtype, 'data', "integer like")
 
     def __str__(self):
@@ -395,15 +395,11 @@ class SpikeData(DiscreteData):
         Creates the default channel labels
         """
 
-        if self.data is not None:
-            # channel entries in self.data are 0-based
-            chan_max = self.channel_idx.max()
-            channel_labels = np.array(["channel" + str(int(i + 1)).zfill(len(str(chan_max)) + 1)
-                                       for i in self.channel_idx])
-            return channel_labels
-
-        else:
-            return None
+        # channel entries in self.data are 0-based
+        chan_max = self.channel_idx.max()
+        channel_labels = np.array(["channel" + str(int(i + 1)).zfill(len(str(chan_max)) + 1)
+                                   for i in self.channel_idx])
+        return channel_labels
 
     @property
     def unit(self):
@@ -453,12 +449,9 @@ class SpikeData(DiscreteData):
         Creates the default unit labels
         """
 
-        if self.data is not None:
-            unit_max = self.unit_idx.max()
-            return np.array(["unit" + str(int(i + 1)).zfill(len(str(unit_max)) + 1)
-                             for i in self.unit_idx])
-        else:
-            return None
+        unit_max = self.unit_idx.max()
+        return np.array(["unit" + str(int(i + 1)).zfill(len(str(unit_max)) + 1)
+                         for i in self.unit_idx])
 
     # Helper function that extracts by-trial unit-indices
     def _get_unit(self, trials, units=None):

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -375,7 +375,7 @@ class SpikeData(DiscreteData):
         if nChan != len(chan):
             raise SPYValueError(f"exactly {nChan} channel labels")
         array_parser(chan, varname="channel", ntype="str", dims=(nChan, ))
-        self._channel = chan
+        self._channel = np.array(chan)
 
     def _default_channel_labels(self):
 

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -56,7 +56,6 @@ class DiscreteData(BaseData, ABC):
         self._set_dataset_property(inData, "data")
 
         if inData is not None:
-            # probably not the most elegant way..
             if not np.issubdtype(self.data.dtype, np.integer):
                 raise SPYTypeError(self.data.dtype, 'data', "integer like")
 

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -455,7 +455,7 @@ class SpikeData(DiscreteData):
 
         if self.data is not None:
             unit_max = self.unit_idx.max()
-            return np.array(["unit" + str(int(i)).zfill(len(str(unit_max)) + 1)
+            return np.array(["unit" + str(int(i + 1)).zfill(len(str(unit_max)) + 1)
                              for i in self.unit_idx])
         else:
             return None

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -57,7 +57,7 @@ class DiscreteData(BaseData, ABC):
 
         if inData is not None:
             # probably not the most elegant way..
-            if 'int' not in str(self.data.dtype):
+            if np.issubdtype(self.data.dtype, np.integer):
                 raise SPYTypeError(self.data.dtype, 'data', "integer like")
 
     def __str__(self):
@@ -161,7 +161,7 @@ class DiscreteData(BaseData, ABC):
 
         if self.data is None:
             SPYError("SyNCoPy core - trialid: Cannot assign `trialid` without data. " +
-                     "Please assing data first")
+                     "Please assign data first")
             return
         scount = np.nanmax(self.data[:, self.dimord.index("sample")])
         try:
@@ -334,7 +334,7 @@ class SpikeData(DiscreteData):
     _stackingDimLabel = "sample"
     _selectionKeyWords = DiscreteData._selectionKeyWords + ('channel', 'unit',)
 
-    def _compute_unique(self):
+    def _compute_unique_idx(self):
         """
         Use `np.unique` on whole(!) dataset to compute globally
         available channel and unit indices only once
@@ -379,7 +379,7 @@ class SpikeData(DiscreteData):
         # the constructor was called with data=None, hence
         # we have to compute the unique indices here
         if self.channel_idx is None:
-            self._compute_unique()
+            self._compute_unique_idx()
 
         # we need as many labels as there are distinct channels
         nChan = self.channel_idx.size
@@ -425,7 +425,7 @@ class SpikeData(DiscreteData):
         # the constructor was called with data=None, hence
         # we have to compute this here
         if self.unit_idx is None:
-            self._compute_unique()
+            self._compute_unique_idx()
 
         if unit is None and self.data is not None:
             raise SPYValueError("Cannot set `unit` to `None` with existing data.")
@@ -557,7 +557,7 @@ class SpikeData(DiscreteData):
                          dimord=dimord)
 
         # for fast lookup and labels
-        self._compute_unique()
+        self._compute_unique_idx()
 
         # constructor gets `data=None` for
         # empty inits, selections and loading from file

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -57,7 +57,7 @@ class DiscreteData(BaseData, ABC):
 
         if inData is not None:
             # probably not the most elegant way..
-            if np.issubdtype(self.data.dtype, np.integer):
+            if not np.issubdtype(self.data.dtype, np.integer):
                 raise SPYTypeError(self.data.dtype, 'data', "integer like")
 
     def __str__(self):

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -366,19 +366,20 @@ class SpikeData(DiscreteData):
     def channel(self, chan):
 
         if chan is None and self.data is not None:
-            raise SPYValueError("Cannot set `channel` to `None` with existing data.")
+            raise SPYValueError("channel labels, cannot set `channel` to `None` with existing data.")
         elif self.data is None and chan is not None:
-            raise SPYValueError("Cannot assign `channel` without data. " +
+            raise SPYValueError(f"non-empty SpikeData", "cannot assign `channel` without data. " +
                                 "Please assign data first")
         elif chan is None:
             self._channel = chan
             return
 
-        nChan = np.max(self.data[:, self.dimord.index("channel")]) + 1
-        try:
-            array_parser(chan, varname="channel", ntype="str", dims=(nChan, ))
-        except Exception as exc:
-            raise exc
+        # we need at least as many labels as there are distinct channels
+        nChan_min = np.unique(self.data[:, self.dimord.index("channel")]).size
+
+        if nChan_min > len(chan):
+            raise SPYValueError(f"at least {nChan_min} labels")
+        array_parser(chan, varname="channel", ntype="str")
 
         self._channel = chan
 
@@ -418,10 +419,8 @@ class SpikeData(DiscreteData):
             return
 
         nunit = np.unique(self.data[:, self.dimord.index("unit")]).size
-        try:
-            array_parser(unit, varname="unit", ntype="str", dims=(nunit,))
-        except Exception as exc:
-            raise exc
+        array_parser(unit, varname="unit", ntype="str", dims=(nunit,))
+
         self._unit = np.array(unit)
 
     def _get_default_unit(self):

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -318,7 +318,9 @@ class DiscreteData(BaseData, ABC):
 
                 # Fill in dimensional info
                 definetrial(self, kwargs.get("trialdefinition"))
-
+        elif self.data.size == 0:
+            # initialization with empty data not allowed
+            raise SPYValueError("non empty data set", 'data')
 
 class SpikeData(DiscreteData):
     """Spike times of multi- and/or single units

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -310,17 +310,17 @@ class DiscreteData(BaseData, ABC):
         # Call initializer
         super().__init__(data=data, **kwargs)
 
-        if self.data is not None and self.data.size != 0:
+        if self.data is not None:
+
+            if self.data.size == 0:
+                # initialization with empty data not allowed
+                raise SPYValueError("non empty data set", 'data')
 
             # In case of manual data allocation (reading routine would leave a
             # mark in `cfg`), fill in missing info
             if self.sampleinfo is None:
-
                 # Fill in dimensional info
                 definetrial(self, kwargs.get("trialdefinition"))
-        elif self.data.size == 0:
-            # initialization with empty data not allowed
-            raise SPYValueError("non empty data set", 'data')
 
 class SpikeData(DiscreteData):
     """Spike times of multi- and/or single units

--- a/syncopy/tests/test_basedata.py
+++ b/syncopy/tests/test_basedata.py
@@ -61,12 +61,12 @@ class TestBaseData():
     seed = np.random.RandomState(13)
     data["SpikeData"] = np.vstack([seed.choice(nSamples, size=nSpikes),
                                    seed.choice(nChannels, size=nSpikes),
-                                   seed.choice(int(nChannels / 2), size=nSpikes)]).T
+                                   seed.choice(int(nChannels / 2), size=nSpikes)]).T.astype(int)
     trl["SpikeData"] = trl["AnalogData"]
 
     # Use a simple binary trigger pattern to simulate EventData
     data["EventData"] = np.vstack([np.arange(0, nSamples, 5),
-                                   np.zeros((int(nSamples / 5), ))]).T
+                                   np.zeros((int(nSamples / 5), ))]).T.astype(int)
     data["EventData"][1::2, 1] = 1
     trl["EventData"] = trl["AnalogData"]
 

--- a/syncopy/tests/test_basedata.py
+++ b/syncopy/tests/test_basedata.py
@@ -278,7 +278,7 @@ class TestBaseData():
 
             # Start w/the one operator that does not handle zeros well...
             with pytest.raises(SPYValueError) as spyval:
-                dummy / 0
+                _ = dummy / 0
                 assert "expected non-zero scalar for division" in str(spyval.value)
 
             # Go through all supported operators and try to sabotage them
@@ -374,8 +374,8 @@ class TestBaseData():
             # Difference in actual numerical data
             dummy3 = dummy.copy()
             for dsetName in dummy3._hdfFileDatasetProperties:
-                getattr(dummy3, dsetName)[0] = 2 * np.pi
-            assert dummy3 != dummy
+                getattr(dummy3, dsetName)[0, 0] = -99
+            assert dummy3.data != dummy.data
 
             del dummy, dummy3, other
 

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -43,6 +43,26 @@ class TestSpikeData():
     num_chn = data[:, 1].max() + 1
     num_unt = data[:, 2].max() + 1
 
+    def test_init(self):
+
+        # data and no labels triggers default labels
+        dummy = SpikeData(data=4  * np.ones((2, 3), dtype=int))
+        # labels are 0-based
+        assert dummy.channel == 'channel05'
+        assert dummy.unit == 'unit05'
+
+        # data and fitting labels is fine
+        assert isinstance(SpikeData(data=np.ones((2, 3), dtype=int), channel=['only_channel']),
+                          SpikeData)
+
+        # data and too many labels
+        with pytest.raises(SPYValueError, match='expected exactly 1 unit'):
+            _ = SpikeData(data=np.ones((2, 3), dtype=int), unit=['unit1', 'unit2'])
+
+        # no data but labels
+        with pytest.raises(SPYValueError, match='cannot assign `channel` without data'):
+            _ = SpikeData(channel=['a', 'b', 'c'])
+
     def test_empty(self):
         dummy = SpikeData()
         assert len(dummy.cfg) == 0
@@ -54,9 +74,11 @@ class TestSpikeData():
             SpikeData({})
 
     def test_issue_257_fixed_no_error_for_empty_data(self):
-        """This tests that the data object is created without throwing an error, see #257."""
+        """This tests that empty datasets are not allowed"""
         with pytest.raises(SPYValueError, match='non empty'):
-            data = SpikeData(np.column_stack(([],[],[])), dimord = ['sample', 'channel', 'unit'], samplerate = 30000)
+            data = SpikeData(np.column_stack(([],[],[])).astype(int),
+                             dimord=['sample', 'channel', 'unit'],
+                             samplerate=30000)
 
     def test_nparray(self):
         dummy = SpikeData(self.data)
@@ -147,92 +169,6 @@ class TestSpikeData():
             del dummy, dummy2
             time.sleep(0.1)
 
-    # test data-selection via class method
-    def test_dataselection(self):
-
-        # Create testing objects (regular and swapped dimords)
-        dummy = SpikeData(data=self.data,
-                          trialdefinition=self.trl,
-                          samplerate=2.0)
-        ymmud = SpikeData(data=self.data[:, ::-1],
-                          trialdefinition=self.trl,
-                          samplerate=2.0,
-                          dimord=dummy.dimord[::-1])
-
-        # selections are chosen so that result is not empty
-        trialSelections = [
-            "all",  # enforce below selections in all trials of `dummy`
-            [3, 1]  # minimally unordered
-        ]
-        chanSelections = [
-            ["channel03", "channel01", "channel01", "channel02"],  # string selection w/repetition + unordered
-            [4, 2, 2, 5, 5],   # repetition + unorderd
-            range(5, 8),  # narrow range
-        ]
-        latencySelections = [
-            [0.5, 2.5],  # regular range
-            [1.0, 2]  # recued range
-        ]
-        unitSelections = [
-            ["unit1", "unit1", "unit2", "unit3"],  # preserve repetition
-            [0, 0, 2, 3],  # preserve repetition, don't convert to slice
-            range(1, 4),  # narrow range
-        ]
-
-        timeSelections = list(zip(["latency"] * len(latencySelections), latencySelections))
-
-        trialSels = [random.choice(trialSelections)]
-        chanSels = [random.choice(chanSelections)]
-        unitSels = [random.choice(unitSelections)]
-        timeSels = [random.choice(timeSelections)]
-
-        for obj in [dummy, ymmud]:
-            chanIdx = obj.dimord.index("channel")
-            unitIdx = obj.dimord.index("unit")
-            chanArr = np.arange(obj.channel.size)
-            for trialSel in trialSels:
-                for chanSel in chanSels:
-                    for unitSel in unitSels:
-                        for timeSel in timeSels:
-                            kwdict = {}
-                            kwdict["trials"] = trialSel
-                            kwdict["channel"] = chanSel
-                            kwdict["unit"] = unitSel
-                            kwdict[timeSel[0]] = timeSel[1]
-                            cfg = StructDict(kwdict)
-                            # data selection via class-method + `Selector` instance for indexing
-
-                            selected = obj.selectdata(**kwdict)
-                            obj.selectdata(**kwdict, inplace=True)
-                            selector = obj.selection
-                            tk = 0
-                            for trialno in selector.trial_ids:
-                                if selector.time[tk]:
-                                    assert np.array_equal(obj.trials[trialno][selector.time[tk], :],
-                                                          selected.trials[tk])
-                                    tk += 1
-                            assert set(selected.data[:, chanIdx]).issubset(chanArr[selector.channel])
-                            assert set(selected.channel) == set(obj.channel[selector.channel])
-                            # only if we got sth
-                            if np.size(selected.unit) > 0:
-                                assert np.array_equal(selected.unit,
-                                                      obj.unit[np.unique(selected.data[:, unitIdx])])
-                            cfg.data = obj
-                            # data selection via package function and `cfg`: ensure equality
-                            out = selectdata(cfg)
-                            assert np.array_equal(out.channel, selected.channel)
-                            assert np.array_equal(out.unit, selected.unit)
-                            assert np.array_equal(out.data, selected.data)
-
-    def test_parallel(self, testcluster):
-        # repeat selected test w/parallel processing engine
-        client = dd.Client(testcluster)
-        par_tests = ["test_dataselection"]
-        for test in par_tests:
-            getattr(self, test)()
-            flush_local_cluster(testcluster)
-        client.close()
-
 
 class TestEventData():
 
@@ -240,7 +176,7 @@ class TestEventData():
     nc = 10
     ns = 30
     data = np.vstack([np.arange(0, ns, 5),
-                      np.zeros((int(ns / 5), ))]).T
+                      np.zeros((int(ns / 5), ))]).T.astype(int)
     data[1::2, 1] = 1
     data2 = data.copy()
     data2[:, -1] = data[:, 0]
@@ -451,7 +387,7 @@ class TestEventData():
 
         # Extend data and provoke an exception due to out of bounds error
         smp = np.vstack([np.arange(self.ns, int(2.5 * self.ns), 5),
-                         np.zeros((int((1.5 * self.ns) / 5),))]).T
+                         np.zeros((int((1.5 * self.ns) / 5),))]).T.astype(int)
         smp[1::2, 1] = 1
         smp = np.hstack([smp, smp])
         data4 = np.vstack([data3, smp])
@@ -581,3 +517,4 @@ class TestEventData():
 if __name__ == '__main__':
 
     T1 = TestSpikeData()
+    T2 = TestEventData()

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -55,8 +55,8 @@ class TestSpikeData():
 
     def test_issue_257_fixed_no_error_for_empty_data(self):
         """This tests that the data object is created without throwing an error, see #257."""
-        data = SpikeData(np.column_stack(([],[],[])), dimord = ['sample', 'channel', 'unit'], samplerate = 30000)
-        assert data.dimord == ["sample", "channel", "unit"]
+        with pytest.raises(SPYValueError, match='non empty'):
+            data = SpikeData(np.column_stack(([],[],[])), dimord = ['sample', 'channel', 'unit'], samplerate = 30000)
 
     def test_nparray(self):
         dummy = SpikeData(self.data)

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -55,6 +55,16 @@ class TestSpikeData():
         assert isinstance(SpikeData(data=np.ones((2, 3), dtype=int), channel=['only_channel']),
                           SpikeData)
 
+        # --- invalid inits ---
+
+        # non-integer types
+        with pytest.raises(SPYTypeError, match='expected integer like'):
+            _ = SpikeData(data=np.ones((2, 3)), unit=['unit1', 'unit2'])
+
+        with pytest.raises(SPYTypeError, match='expected integer like'):
+            data = np.array([np.nan, 2, np.nan])[:, np.newaxis]
+            _ = SpikeData(data=data, unit=['unit1', 'unit2'])
+
         # data and too many labels
         with pytest.raises(SPYValueError, match='expected exactly 1 unit'):
             _ = SpikeData(data=np.ones((2, 3), dtype=int), unit=['unit1', 'unit2'])

--- a/syncopy/tests/test_spyio.py
+++ b/syncopy/tests/test_spyio.py
@@ -35,6 +35,7 @@ on_esi = os.path.isdir('/cs/slurm/syncopy')
 skip_no_esi = pytest.mark.skipif(not on_esi, reason="ESI fs not available")
 skip_no_nwb = pytest.mark.skipif(not spy.__nwb__, reason="pynwb not installed")
 
+
 class TestSpyIO():
 
     # Allocate test-datasets for AnalogData, SpectralData, SpikeData and EventData objects
@@ -65,12 +66,12 @@ class TestSpyIO():
     seed = np.random.RandomState(13)
     data["SpikeData"] = np.vstack([seed.choice(ns, size=nd),
                                    seed.choice(nc, size=nd),
-                                   seed.choice(int(nc / 2), size=nd)]).T
+                                   seed.choice(int(nc / 2), size=nd)]).T.astype(int)
     trl["SpikeData"] = trl["AnalogData"]
 
     # Generate bogus trigger timings
     data["EventData"] = np.vstack([np.arange(0, ns, 5),
-                                   np.zeros((int(ns / 5), ))]).T
+                                   np.zeros((int(ns / 5), ))]).T.astype(int)
     data["EventData"][1::2, 1] = 1
     trl["EventData"] = trl["AnalogData"]
 
@@ -613,6 +614,7 @@ class TestNWBImporter:
 
 
 if __name__ == '__main__':
+    T0 = TestSpyIO()
     T1 = TestFTImporter()
     T2 = TestTDTImporter()
     T3 = TestNWBImporter()


### PR DESCRIPTION
Changes Summary
---------------------------
This PR does 2 things, but can't follow the original idea about *contiguous channel labels*
- new attributes for `SpikeData`: `.channel_idx` and `.unit_idx`, holding the `np.unique` results 
- `.channel`/`.unit` property lookups are no longer re-computed and hence as fast as they should be
- checks for integer data type of `.data` for `DiscreteData`

I hope I captured what you had in mind @kshapcott, here's an example how it works now:
```python
spd = spy.SpikeData(data = 4 * np.ones((5,3), dtype=int), channel=['my_only_channel'])

# assigned label
spd.channel
>>> array(['my_only_channel'], dtype='<U15')

# there's only channel 4
spd.channel_idx
>>> array([4])

# default label
spd.unit
>>> array(['unit05'], dtype='<U6')

# there's only unit 4
spd.unit_idx
>>> array([4])
```
Note that both `channel` and `unit` use 0-indexing now, before only channel was 0-based for some reason.

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
