### PR TITLE
NEW: TrialIndexer

### DIFF
--- a/syncopy/__init__.py
+++ b/syncopy/__init__.py
@@ -127,7 +127,7 @@ from .plotting import *
 from .preproc import *
 
 # Register session
-__session__ = datatype.base_data.SessionLogger()
+__session__ = datatype.util.SessionLogger()
 
 # Override default traceback (differentiate b/w Jupyter/iPython and regular Python)
 from .shared.errors import SPYExceptionHandler

--- a/syncopy/datatype/__init__.py
+++ b/syncopy/datatype/__init__.py
@@ -13,6 +13,7 @@ from .methods.padding import *
 from .methods.selectdata import *
 from .methods.show import *
 from .methods.copy import *
+from .util import *
 
 # Populate local __all__ namespace
 __all__ = []
@@ -25,3 +26,4 @@ __all__.extend(methods.definetrial.__all__)
 __all__.extend(methods.selectdata.__all__)
 __all__.extend(methods.show.__all__)
 __all__.extend(methods.copy.__all__)
+__all__.extend(util.__all__)

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -10,11 +10,8 @@ import time
 import sys
 import os
 from abc import ABC, abstractmethod
-from datetime import datetime
 from hashlib import blake2b
-from itertools import islice
 from functools import reduce
-from inspect import signature
 import shutil
 import numpy as np
 import h5py
@@ -22,6 +19,7 @@ import scipy as sp
 
 # Local imports
 import syncopy as spy
+from .util import TrialIndexer
 from .methods.arithmetic import _process_operator
 from .methods.selectdata import selectdata
 from .methods.show import show
@@ -744,8 +742,13 @@ class BaseData(ABC):
     def trials(self):
         """list-like array of trials"""
 
-        return Indexer(map(self._get_trial, range(self.sampleinfo.shape[0])),
-                       self.sampleinfo.shape[0]) if self.sampleinfo is not None else None
+        if self.sampleinfo is not None:
+            trial_ids = list(range(self.sampleinfo.shape[0]))
+            # this is cheap as it just initializes a list-like object
+            # with no real data and/or computation!
+            return TrialIndexer(self, trial_ids)
+        else:
+            return None
 
     @property
     def trialinfo(self):
@@ -1161,147 +1164,6 @@ class BaseData(ABC):
         self._version = __version__
 
 
-class Indexer:
-
-    __slots__ = ["_iterobj", "_iterlen"]
-
-    def __init__(self, iterobj, iterlen):
-        """
-        Make an iterable object subscriptable using itertools magic
-        """
-        self._iterobj = iterobj
-        self._iterlen = iterlen
-
-    def __iter__(self):
-        return self._iterobj
-
-    def __getitem__(self, idx):
-        if np.issubdtype(type(idx), np.number):
-            try:
-                scalar_parser(
-                    idx, varname="idx", ntype="int_like", lims=[0, self._iterlen - 1]
-                )
-            except Exception as exc:
-                raise exc
-            return next(islice(self._iterobj, idx, idx + 1))
-        elif isinstance(idx, slice):
-            start, stop = idx.start, idx.stop
-            if idx.start is None:
-                start = 0
-            if idx.stop is None:
-                stop = self._iterlen
-            index = slice(start, stop, idx.step)
-            if not (0 <= index.start < self._iterlen) or not (
-                0 < index.stop <= self._iterlen
-            ):
-                err = "value between {lb:s} and {ub:s}"
-                raise SPYValueError(
-                    err.format(lb="0", ub=str(self._iterlen)),
-                    varname="idx",
-                    actual=str(index),
-                )
-            return np.hstack(islice(self._iterobj, index.start, index.stop, index.step))
-        elif isinstance(idx, (list, np.ndarray)):
-            try:
-                array_parser(
-                    idx,
-                    varname="idx",
-                    ntype="int_like",
-                    hasnan=False,
-                    hasinf=False,
-                    lims=[0, self._iterlen],
-                    dims=1,
-                )
-            except Exception as exc:
-                raise exc
-            return np.hstack(
-                [next(islice(self._iterobj, int(ix), int(ix + 1))) for ix in idx]
-            )
-        else:
-            raise SPYTypeError(idx, varname="idx", expected="int_like or slice")
-
-    def __len__(self):
-        return self._iterlen
-
-    def __repr__(self):
-        return self.__str__()
-
-    def __str__(self):
-        return "{} element iterable".format(self._iterlen)
-
-
-class SessionLogger:
-
-    __slots__ = ["sessionfile", "_rm"]
-
-    def __init__(self):
-
-        # Create package-wide tmp directory if not already present
-        if not os.path.exists(__storage__):
-            try:
-                os.mkdir(__storage__)
-            except Exception as exc:
-                err = (
-                    "Syncopy core: cannot create temporary storage directory {}. "
-                    + "Original error message below\n{}"
-                )
-                raise IOError(err.format(__storage__, str(exc)))
-
-        # Check for upper bound of temp directory size
-        with os.scandir(__storage__) as scan:
-            st_size = 0.0
-            st_fles = 0
-            for fle in scan:
-                try:
-                    st_size += fle.stat().st_size / 1024 ** 3
-                    st_fles += 1
-                # this catches a cleanup by another process
-                except FileNotFoundError:
-                    continue
-
-            if st_size > __storagelimit__:
-                msg = (
-                    "\nSyncopy <core> WARNING: Temporary storage folder {tmpdir:s} "
-                    + "contains {nfs:d} files taking up a total of {sze:4.2f} GB on disk. \n"
-                    + "Consider running `spy.cleanup()` to free up disk space."
-                )
-                print(msg.format(tmpdir=__storage__, nfs=st_fles, sze=st_size))
-
-        # If we made it to this point, (attempt to) write the session file
-        sess_log = "{user:s}@{host:s}: <{time:s}> started session {sess:s}"
-        self.sessionfile = os.path.join(
-            __storage__, "session_{}_log.id".format(__sessionid__)
-        )
-        try:
-            with open(self.sessionfile, "w") as fid:
-                fid.write(
-                    sess_log.format(
-                        user=getpass.getuser(),
-                        host=socket.gethostname(),
-                        time=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                        sess=__sessionid__,
-                    )
-                )
-        except Exception as exc:
-            err = "Syncopy core: cannot access {}. Original error message below\n{}"
-            raise IOError(err.format(self.sessionfile, str(exc)))
-
-        # Workaround to prevent Python from garbage-collecting ``os.unlink``
-        self._rm = os.unlink
-
-    def __repr__(self):
-        return self.__str__()
-
-    def __str__(self):
-        return "Session {}".format(__sessionid__)
-
-    def __del__(self):
-        try:
-            self._rm(self.sessionfile)
-        except FileNotFoundError:
-            pass
-
-
 class FauxTrial:
     """
     Stand-in mockup of NumPy arrays representing trial data
@@ -1617,23 +1479,28 @@ class Selector:
                 raise SPYValueError(legal=lgl, varname=vname, actual=act)
         else:
             trials = trlList
-        self._trial_ids = list(trials) # ensure `trials` is a list cf. #180
+        self._trial_ids = list(trials)  # ensure `trials` is a list cf. #180
 
     @property
     def trials(self):
         """
-        Returns an Indexer indexing single trial arrays respecting the selection
-        Indices are RELATIVE with respect to existing trial selections:
+        Returns an iterable indexing single trial arrays respecting the selection
+        Indices are ABSOLUTE with respect to existing trial selections:
 
-        >>> selection.trials[2]
+        >>> selection.trials[11]
 
-        indexes the 3rd trial of `selection.trial_ids`
+        indexes the 11th trial of the original dataset, if and only if 
+        trial number 11 is part of the selection.
 
         Selections must be "simple": ordered and without repetitions
         """
 
-        return Indexer(map(self._get_trial, self.trial_ids),
-                       len(self.trial_ids)) if self.trial_ids is not None else None
+        if self.sampleinfo is not None:
+            # this is cheap as it just initializes a list-like object
+            # with no real data and/or computations!
+            return TrialIndexer(self, self.trial_ids)
+        else:
+            return None
 
     def create_get_trial(self, data):
         """ Closure to allow emulation of BaseData._get_trial"""
@@ -2338,7 +2205,7 @@ class Selector:
                         attr,
                         "s" if not attr.endswith("s") else "",
                     )
-            elif isinstance(val, (list, Indexer)):
+            elif isinstance(val, (list, TrialIndexer)):
                 ppdict[attr] = "{0:d} {1:s}{2:s}, ".format(
                     len(val), attr, "s" if not attr.endswith("s") else ""
                 )

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -11,7 +11,7 @@ import inspect
 
 
 # Local imports
-from .base_data import BaseData, Indexer, FauxTrial
+from .base_data import BaseData, FauxTrial
 from .methods.definetrial import definetrial
 from syncopy.shared.parsers import scalar_parser, array_parser
 from syncopy.shared.errors import SPYValueError
@@ -163,16 +163,6 @@ class DiscreteData(BaseData, ABC):
         except Exception as exc:
             raise exc
         self._trialid = np.array(trlid, dtype=int)
-
-    @property
-    def trials(self):
-        """list-like([sample x (>=2)] :class:`numpy.ndarray`) : trial slices of :attr:`data` property"""
-        if self.trialid is not None:
-            valid_trls = np.unique(self.trialid[self.trialid >= 0])
-            return Indexer(map(self._get_trial, valid_trls),
-                           valid_trls.size)
-        else:
-            return None
 
     @property
     def trialtime(self):

--- a/syncopy/datatype/util.py
+++ b/syncopy/datatype/util.py
@@ -1,0 +1,127 @@
+"""
+Helpers and tools for Syncopy data classes
+"""
+
+import os
+import getpass
+import socket
+from datetime import datetime
+
+# Syncopy imports
+from syncopy import __storage__, __storagelimit__, __sessionid__
+from syncopy.shared.errors import SPYTypeError, SPYValueError
+
+__all__ = ['TrialIndexer', 'SessionLogger']
+
+
+class TrialIndexer(list):
+
+    def __init__(self, data_object, idx_list):
+        """
+        Subclass Python's list to obtain an indexable trials iterable.
+        Relies on the `_get_trial` method of the
+        respective `data_object`.
+
+        Parameters
+        ----------
+        data_object : Syncopy data class, e.g. AnalogData
+
+        idx_list : list
+            List of valid trial indices for `_get_trial`
+        """
+        self.data_object = data_object
+        self.idx_list = idx_list
+        self._len = len(idx_list)
+
+    def __getitem__(self, trialno):
+        if trialno not in self.idx_list:
+            lgl = "index of existing trials"
+            raise SPYValueError(lgl, "trial index", trialno)
+        return self.data_object._get_trial(trialno)
+
+    def __iter__(self):
+        # this generator gets freshly created and exhausted
+        # only for iterations (iterator protocol)
+        yield from (self[i] for i in self.idx_list)
+
+    def __len__(self):
+        return self._len
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return "{} element iterable".format(self._len)
+
+
+class SessionLogger:
+
+    __slots__ = ["sessionfile", "_rm"]
+
+    def __init__(self):
+
+        # Create package-wide tmp directory if not already present
+        if not os.path.exists(__storage__):
+            try:
+                os.mkdir(__storage__)
+            except Exception as exc:
+                err = (
+                    "Syncopy core: cannot create temporary storage directory {}. "
+                    + "Original error message below\n{}"
+                )
+                raise IOError(err.format(__storage__, str(exc)))
+
+        # Check for upper bound of temp directory size
+        with os.scandir(__storage__) as scan:
+            st_size = 0.0
+            st_fles = 0
+            for fle in scan:
+                try:
+                    st_size += fle.stat().st_size / 1024 ** 3
+                    st_fles += 1
+                # this catches a cleanup by another process
+                except FileNotFoundError:
+                    continue
+
+            if st_size > __storagelimit__:
+                msg = (
+                    "\nSyncopy <core> WARNING: Temporary storage folder {tmpdir:s} "
+                    + "contains {nfs:d} files taking up a total of {sze:4.2f} GB on disk. \n"
+                    + "Consider running `spy.cleanup()` to free up disk space."
+                )
+                print(msg.format(tmpdir=__storage__, nfs=st_fles, sze=st_size))
+
+        # If we made it to this point, (attempt to) write the session file
+        sess_log = "{user:s}@{host:s}: <{time:s}> started session {sess:s}"
+        self.sessionfile = os.path.join(
+            __storage__, "session_{}_log.id".format(__sessionid__)
+        )
+        try:
+            with open(self.sessionfile, "w") as fid:
+                fid.write(
+                    sess_log.format(
+                        user=getpass.getuser(),
+                        host=socket.gethostname(),
+                        time=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                        sess=__sessionid__,
+                    )
+                )
+        except Exception as exc:
+            err = "Syncopy core: cannot access {}. Original error message below\n{}"
+            raise IOError(err.format(self.sessionfile, str(exc)))
+
+        # Workaround to prevent Python from garbage-collecting ``os.unlink``
+        self._rm = os.unlink
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return "Session {}".format(__sessionid__)
+
+    def __del__(self):
+        try:
+            self._rm(self.sessionfile)
+        except FileNotFoundError:
+            pass
+    

--- a/syncopy/statistics/spike_psth.py
+++ b/syncopy/statistics/spike_psth.py
@@ -11,7 +11,6 @@ import syncopy as spy
 from syncopy.shared.parsers import data_parser, scalar_parser, array_parser
 from syncopy.shared.tools import get_defaults, get_frontend_cfg
 from syncopy.datatype import TimeLockData
-from syncopy.datatype.base_data import Indexer
 
 from syncopy.shared.errors import SPYValueError, SPYTypeError, SPYInfo
 from syncopy.shared.kwarg_decorators import (

--- a/syncopy/statistics/summary_stats.py
+++ b/syncopy/statistics/summary_stats.py
@@ -274,7 +274,6 @@ def _statistics(spy_data, operation, dim, keeptrials=True, **kwargs):
         if kwargs.get('parallel'):
             msg = "Trial statistics can be only computed sequentially, ignoring `parallel` keyword"
             SPYWarning(msg)
-
         out = _trial_statistics(spy_data, operation)
 
     # any other statistic
@@ -447,8 +446,10 @@ def _trial_statistics(in_data, operation='mean'):
         act = f"got {nTrials} trials"
         raise SPYValueError(lgl, 'in_data', act)
 
+    # index 1st selected trial
+    idx0 = in_data.selection.trial_ids[0]
     # we always have at least one (all-to-all) trial selection
-    out_shape = in_data.selection.trials[0].shape
+    out_shape = in_data.selection.trials[idx0].shape
 
     # now look at the other ones
     for trl in in_data.selection.trials:

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -654,15 +654,14 @@ class TestSelector():
         # checks time axis
         assert len(ang.selection.trials) == 3
 
-        # test for non-existing trials, trial indices are relative here!
+        # trial indices are absolute here!
         select = {'trials': [0, 3, 5]}
         ang.selectdata(**select, inplace=True)
         assert ang.selection.trial_ids[2] == 5
-        # this returns original trial 6 (with index 5)
-        assert np.array_equal(ang.selection.trials[2], ang.trials[5])
-        # we only have 3 trials selected here, so max. relative index is 2
-        with pytest.raises(SPYValueError, match='less or equals 2'):
-            ang.selection.trials[5]
+        assert np.array_equal(ang.selection.trials[5], ang.trials[5])
+        # test access of non-selected trial fails
+        with pytest.raises(SPYValueError, match='expected index of existing trials'):
+            ang.selection.trials[1]
 
         # Fancy indexing is not allowed so far
         select = {'channel': [7, 7, 8]}


### PR DESCRIPTION
Changes Summary
----------------
- replaces the somewhat over-engineered yet still inefficient `Indexer`, backing the `.trials` property
- the new `TrialIndexer` can also be used both as an iterable or via explicit (single element) indexing


Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
