### PR TITLE
Add log function to syncopy root namespace

### DIFF
--- a/syncopy/__init__.py
+++ b/syncopy/__init__.py
@@ -180,3 +180,5 @@ __all__.extend(nwanalysis.__all__)
 __all__.extend(statistics.__all__)
 __all__.extend(plotting.__all__)
 __all__.extend(preproc.__all__)
+__all__.extend(shared.errors.log)
+

--- a/syncopy/__init__.py
+++ b/syncopy/__init__.py
@@ -170,6 +170,8 @@ try:
 except:
     sys.excepthook = SPYExceptionHandler
 
+from .shared.errors import log
+
 # Manage user-exposed namespace imports
 __all__ = []
 __all__.extend(datatype.__all__)
@@ -180,5 +182,5 @@ __all__.extend(nwanalysis.__all__)
 __all__.extend(statistics.__all__)
 __all__.extend(plotting.__all__)
 __all__.extend(preproc.__all__)
-__all__.extend(shared.errors.log)
+
 

--- a/syncopy/shared/errors.py
+++ b/syncopy/shared/errors.py
@@ -369,7 +369,7 @@ def SPYLog(msg, loglevel="INFO", caller=None):
     logfunc(PrintMsg.format(caller=" <" + caller + ">" if len(caller) else caller,
                           msg=msg))
 
-def log(msg, level="INFO", par=False, caller=None):
+def log(msg, level="IMPORTANT", par=False, caller=None):
     """
     Log a message using the Syncopy logging setup.
 

--- a/syncopy/shared/errors.py
+++ b/syncopy/shared/errors.py
@@ -333,6 +333,10 @@ def SPYParallelLog(msg, loglevel="INFO", caller=None):
     """Log a message in parallel code run via slurm.
 
     This uses the parallel logger and one file per machine.
+
+    Returns
+    -------
+    Nothing : None
     """
     numeric_level = getattr(logging, loglevel.upper(), None)
     if not isinstance(numeric_level, int):  # Invalid string was set.
@@ -346,9 +350,13 @@ def SPYParallelLog(msg, loglevel="INFO", caller=None):
                           msg=msg))
 
 def SPYLog(msg, loglevel="INFO", caller=None):
-    """Log a message in seqiential code.
+    """Log a message in sequential code.
 
-    This uses the standard logger that logs to console by default.
+    This uses the standard logger that logs to console and a local log file by default.
+
+    Returns
+    -------
+    Nothing : None
     """
     numeric_level = getattr(logging, loglevel.upper(), None)
     if not isinstance(numeric_level, int):  # Invalid string was set.
@@ -360,6 +368,30 @@ def SPYLog(msg, loglevel="INFO", caller=None):
     logfunc = getattr(logger, loglevel.lower())
     logfunc(PrintMsg.format(caller=" <" + caller + ">" if len(caller) else caller,
                           msg=msg))
+
+def log(msg, level="INFO", par=False, caller=None):
+    """
+    Log a message using the Syncopy logging setup.
+
+    Parameters
+    ----------
+    msg    : str
+        The message to be logged.
+    level  : str
+        One of 'DEBUG', 'IMPORTANT', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'.
+    caller : None or str
+        Issuer of warning message. If `None`, name of calling method is
+        automatically fetched and pre-pended to `msg`.
+    par    : bool, whether to use the parallel logger.
+
+    Returns
+    -------
+    Nothing : None
+    """
+    if par:
+        SPYParallelLog(msg, loglevel=level, caller=caller)
+    else:
+        SPYLog(msg, loglevel=level, caller=caller)
 
 
 def SPYInfo(msg, caller=None, tag="INFO"):

--- a/syncopy/tests/test_logging.py
+++ b/syncopy/tests/test_logging.py
@@ -70,6 +70,49 @@ class TestLogging:
         num_lines_after_warning = sum(1 for line in open(par_logfile))
         assert num_lines_after_warning > num_lines_after_info_debug
 
+    def test_log_function_is_in_root_namespace_with_seq(self):
+        """Tests sequential logger via spy.log function."""
+        assert os.getenv("SPYLOGLEVEL", "IMPORTANT") == "IMPORTANT"
+
+        logfile = os.path.join(spy.__logdir__, "syncopy.log")
+        assert os.path.isfile(logfile)
+        num_lines_initial = sum(1 for line in open(logfile)) # The log file gets appended, so it will most likely *not* be empty.
+
+        # Log something with log level info and DEBUG, which should not affect the logfile.
+        spy.log("I am adding an INFO level log entry.", level="INFO")
+
+        num_lines_after_info_debug = sum(1 for line in open(logfile))
+        assert num_lines_initial == num_lines_after_info_debug
+
+        # Now log something with log level WARNING
+        spy.log("I am adding a IMPORTANT level log entry.", level="IMPORTANT", par=False)
+        spy.log("This is the last warning.", level="IMPORTANT")
+
+        num_lines_after_warning = sum(1 for line in open(logfile))
+        assert num_lines_after_warning > num_lines_after_info_debug
+
+    def test_log_function_is_in_root_namespace_with_par(self):
+        """Tests parallel logger via spy.log function."""
+        assert os.getenv("SPYPARLOGLEVEL", "IMPORTANT") == "IMPORTANT"
+
+        par_logfile = os.path.join(spy.__logdir__, f"syncopy_{platform.node()}.log")
+        assert os.path.isfile(par_logfile)
+        num_lines_initial = sum(1 for line in open(par_logfile)) # The log file gets appended, so it will most likely *not* be empty.
+
+        # Log something with log level info and DEBUG, which should not affect the logfile.
+        spy.log("I am adding an INFO level log entry.", level="INFO", par=True)
+
+        num_lines_after_info_debug = sum(1 for line in open(par_logfile))
+        assert num_lines_initial == num_lines_after_info_debug
+
+        # Now log something with log level WARNING
+        spy.log("I am adding a IMPORTANT level log entry.", level="IMPORTANT", par=True)
+        spy.log("This is the last warning.", level="IMPORTANT", par=True)
+
+        num_lines_after_warning = sum(1 for line in open(par_logfile))
+        assert num_lines_after_warning > num_lines_after_info_debug
+
+
 
 
 


### PR DESCRIPTION
Changes Summary
----------------
- Adds a `syncopy.log()` function that can be used to log without first importing stuff from submodules, and supports both the sequential and the parallel loggers:

```python
import syncopy as spy
spy.log("We are about to get real.", level="IMPORTANT")
spy.log("oh no, an error in parallel code!", level="ERROR", par=True)
```



Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
