### PR TITLE
New _register_dataset tests

### DIFF
--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -74,6 +74,12 @@ class TestSpikeData():
         with pytest.raises(SPYValueError, match='cannot assign `channel` without data'):
             _ = SpikeData(channel=['a', 'b', 'c'])
 
+    def test_register_dset(self):
+        sdata = SpikeData(self.data, samplerate=10)
+        assert not sdata._is_empty()
+        sdata._register_dataset("blah", np.zeros((3,3), dtype=float))
+
+
     def test_empty(self):
         dummy = SpikeData()
         assert len(dummy.cfg) == 0
@@ -225,6 +231,11 @@ class TestEventData():
         # wrong shape for data-type
         with pytest.raises(SPYValueError):
             EventData(np.ones((3,)))
+
+    def test_register_dset(self):
+        edata = EventData(self.data, samplerate=10)
+        assert not edata._is_empty()
+        edata._register_dataset("blah", np.zeros((3,3), dtype=float))
 
     def test_ed_trialretrieval(self):
         # test ``_get_trial`` with NumPy array: regular order


### PR DESCRIPTION
Changes Summary
----------------
- Add tests that use `_register_dataset()` on `SpikeData` and `EventData` instances.


Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
