### PR TITLE
Waveform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### NEW
 - add logging functionality and respective developer documentation, #208
+- add waveform extra dataset to DiscreteData to store raw data, #238
 
 ### CHANGED
 - major performance improvements for DiscreteData #403 #418, #424

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -421,13 +421,13 @@ class BaseData(ABC):
             act = "backing HDF5 file is closed"
             raise SPYValueError(legal=lgl, actual=act, varname="data")
 
-        # Ensure dataset has right no. of dimensions
-        if inData.ndim != ndim:
-            lgl = "{}-dimensional data".format(ndim)
-            act = "{}-dimensional HDF5 dataset".format(inData.ndim)
-            raise SPYValueError(legal=lgl, varname="data", actual=act)
-
         if propertyName == "data":
+            # Ensure dataset has right no. of dimensions
+            if inData.ndim != ndim:
+                lgl = "{}-dimensional data".format(ndim)
+                act = "{}-dimensional HDF5 dataset".format(inData.ndim)
+                raise SPYValueError(legal=lgl, varname="data", actual=act)
+
             self._check_dataset_property_discretedata(inData)
             self.filename = inData.file.filename
         else:

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -2135,15 +2135,6 @@ class Selector:
             # Finally, prepare new `trialdefinition` array
             self.trialdefinition = data
 
-            # Ensure that `self.waveform` gets selected correctly
-            if self._dataClass == "SpikeData":
-                if data.waveform is not None:
-                    waveform = []
-                    for tk, trialno in enumerate(self.trial_ids):
-                        sel = getattr(self, "_{}".format(actualSelections[0]))[tk]
-                        waveform.append(data.waveform[data._trialslice[trialno],:][sel,:])
-                    self.waveform = np.vstack(waveform)
-
             return
 
         # Count how many lists we got

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -371,15 +371,15 @@ class BaseData(ABC):
             if self.mode == "r":
                 lgl = "dataset with write or copy-on-write access"
                 act = "read-only file"
-                raise SPYValueError(legal=lgl, varname="mode", actual=act)
+                raise SPYValueError(legal=lgl, varname=propertyName, actual=act)
             if prop.shape != inData.shape:
                 lgl = "dataset with shape {}".format(str(prop.shape))
                 act = "data with shape {}".format(str(inData.shape))
-                raise SPYValueError(legal=lgl, varname="data", actual=act)
+                raise SPYValueError(legal=lgl, varname=propertyName, actual=act)
             if prop.dtype != inData.dtype:
                 lgl = "dataset of type {}".format(prop.dtype.name)
                 act = "data of type {}".format(inData.dtype.name)
-                raise SPYValueError(legal=lgl, varname="data", actual=act)
+                raise SPYValueError(legal=lgl, varname=propertyName, actual=act)
             prop[...] = inData
 
         # or create backing file on disk

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -207,7 +207,7 @@ class BaseData(ABC):
 
         supportedSetters[type(inData)](inData, propertyName, ndim=ndim)
 
-    def _unregister_dataset(self, propertyName, del_from_file=True):
+    def _unregister_dataset(self, propertyName, del_from_file=True, del_attr=True):
         """
         Unregister and delete an additional dataset from the Syncopy data object,
         and optionally delete it from the backing hdf5 file.
@@ -220,14 +220,17 @@ class BaseData(ABC):
                 The name of the entry in `self._hdfFileDatasetProperties` to remove.
                 The attribute named `'_' + propertyName` of this SyncopyData object will be deleted.
             del_from_file: bool
-                Whether to also remove the dataset named 'propertyName' from the backing hdf5 file on disk.
+                Whether to remove the dataset named 'propertyName' from the backing hdf5 file on disk.
+            del_attr: bool
+                Whether to remove the dataset attribute from the Syncopy data object.
         """
-        if propertyName in self._hdfFileDatasetProperties:
-            tmp_list = list(self._hdfFileDatasetProperties)
-            tmp_list.remove(propertyName)
-            self._hdfFileDatasetProperties = tuple(tmp_list)
-        if hasattr(self, "_" + propertyName):
-            delattr(self, "_" + propertyName)
+        if del_attr:
+            if propertyName in self._hdfFileDatasetProperties:
+                tmp_list = list(self._hdfFileDatasetProperties)
+                tmp_list.remove(propertyName)
+                self._hdfFileDatasetProperties = tuple(tmp_list)
+            if hasattr(self, "_" + propertyName):
+                delattr(self, "_" + propertyName)
         if del_from_file:
             if self.mode == "r":
                 lgl = "HDF5 dataset with write or copy-on-write access"

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -2106,7 +2106,7 @@ class Selector:
                     chanPerTrial.append(rawChanInTrial[combinedSelect])
                 elif areShuffled:
                     combinedSelect = combinedSelect.tolist()
-                    
+
                 # The usual list -> slice conversion (if possible)
                 if len(combinedSelect) > 1:
                     selSteps = np.diff(combinedSelect)
@@ -2134,6 +2134,15 @@ class Selector:
 
             # Finally, prepare new `trialdefinition` array
             self.trialdefinition = data
+
+            # Ensure that `self.waveform` gets selected correctly
+            if self._dataClass == "SpikeData":
+                if data.waveform is not None:
+                    waveform = []
+                    for tk, trialno in enumerate(self.trial_ids):
+                        sel = getattr(self, "_{}".format(actualSelections[0]))[tk]
+                        waveform.append(data.waveform[data._trialslice[trialno],:][sel,:])
+                    self.waveform = np.vstack(waveform)
 
             return
 

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -531,8 +531,8 @@ class SpikeData(DiscreteData):
             return
 
         if waveform.shape[0] != self.data.shape[0]:
-            raise SPYValueError(f"wrong size waveform", f"waveform shape[0]={waveform.shape[0]} must equal nSpikes={self.data.shape[0]}. " +
-                                "Please create one waveform per spike in data.")
+            raise SPYValueError(f"waveform shape[0]={waveform.shape[0]} must equal nSpikes={self.data.shape[0]}. " +
+                                "Please create one waveform per spike in data.", varname="waveform", actual=f"wrong size waveform with shape {waveform.shape}")
         self._set_dataset_property(waveform, 'waveform')
 
     # "Constructor"

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -512,6 +512,17 @@ class SpikeData(DiscreteData):
 
     @waveform.setter
     def waveform(self, waveform):
+        if self.data is None:
+            if waveform is not None:
+                raise SPYValueError(f"non-empty SpikeData", "cannot assign `waveform` without data. " +
+                                    "Please assign data first")
+        if waveform is None:
+            self._set_dataset_property(waveform, 'waveform') # None
+            return
+
+        if waveform.shape[0] != self.data.shape[0]:
+            raise SPYValueError(f"wrong size waveform", f"waveform shape[0]={waveform.shape[0]} must equal nSpikes={self.data.shape[0]}. " +
+                                "Please create one waveform per spike in data.")
         self._set_dataset_property(waveform, 'waveform')
 
     # "Constructor"

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -523,12 +523,15 @@ class SpikeData(DiscreteData):
         """Set a waveform dataset from a numpy array, `None`, or an `h5py.Dataset` instance."""
         if self.data is None:
             if waveform is not None:
-                raise SPYValueError(f"non-empty SpikeData", "cannot assign `waveform` without data. " +
-                                    "Please assign data first")
+                raise SPYValueError(legal="non-empty SpikeData", varname="waveform",
+                actual="empty SpikeData main dataset (None). Cannot assign `waveform` without data. Please assign data first.")
         if waveform is None:
             self._set_dataset_property(waveform, 'waveform') # None
             self._unregister_dataset("waveform", del_attr=False)
             return
+
+        if waveform.ndim < 2:
+            raise SPYValueError(legal="waveform data with at least 2 dimensions", varname="waveform", actual=f"data with {waveform.ndim} dimensions")
 
         if waveform.shape[0] != self.data.shape[0]:
             raise SPYValueError(f"waveform shape[0]={waveform.shape[0]} must equal nSpikes={self.data.shape[0]}. " +

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -520,12 +520,14 @@ class SpikeData(DiscreteData):
 
     @waveform.setter
     def waveform(self, waveform):
+        """Set a waveform dataset from a numpy array, `None`, or an `h5py.Dataset` instance."""
         if self.data is None:
             if waveform is not None:
                 raise SPYValueError(f"non-empty SpikeData", "cannot assign `waveform` without data. " +
                                     "Please assign data first")
         if waveform is None:
             self._set_dataset_property(waveform, 'waveform') # None
+            self._unregister_dataset("waveform", del_attr=False)
             return
 
         if waveform.shape[0] != self.data.shape[0]:

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -506,6 +506,14 @@ class SpikeData(DiscreteData):
 
         return indices
 
+    @property
+    def waveform(self):
+        return self._waveform
+
+    @waveform.setter
+    def waveform(self, waveform):
+        self._set_dataset_property(waveform, 'waveform')
+
     # "Constructor"
     def __init__(self,
                  data=None,
@@ -547,6 +555,7 @@ class SpikeData(DiscreteData):
 
         # instance attribute to allow modification
         self._hdfFileAttributeProperties = DiscreteData._hdfFileAttributeProperties + ("channel", "unit")
+        self._hdfFileDatasetProperties = DiscreteData._hdfFileDatasetProperties + ("waveform",)
 
         self._unit = None
         self.unit_idx = None
@@ -559,6 +568,8 @@ class SpikeData(DiscreteData):
                          trialdefinition=trialdefinition,
                          samplerate=samplerate,
                          dimord=dimord)
+
+        self._waveform = None
 
         # for fast lookup and labels
         self._compute_unique_idx()

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -508,6 +508,14 @@ class SpikeData(DiscreteData):
 
     @property
     def waveform(self):
+        """The waveform of the spikes in the data.
+
+        This is a tiny part of the raw data around the time point at which a spike was detected
+        (by the recording hardware/software: keep in mind that the spike data Syncopy is working
+        with is already pre-processed). From this sequence of samples, one can derive
+        the waveform type of the spike (via classification), which may allow to
+        derive the type of neuron that produced the spike.
+        """
         return self._waveform
 
     @waveform.setter

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -576,7 +576,6 @@ class SpikeData(DiscreteData):
 
         # instance attribute to allow modification
         self._hdfFileAttributeProperties = DiscreteData._hdfFileAttributeProperties + ("channel", "unit")
-        self._hdfFileDatasetProperties = DiscreteData._hdfFileDatasetProperties + ("waveform",)
 
         self._unit = None
         self.unit_idx = None
@@ -589,6 +588,8 @@ class SpikeData(DiscreteData):
                          trialdefinition=trialdefinition,
                          samplerate=samplerate,
                          dimord=dimord)
+
+        self._hdfFileDatasetProperties +=  ("waveform",)
 
         self._waveform = None
 

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -336,6 +336,8 @@ def selectdata(data,
         selectDict['latency'] = window
         data.selection = selectDict
 
+    print(f"Data.selection is {data.selection}")
+
     # If an in-place selection was requested we're done
     if inplace:
         # attach frontend parameters for replay

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -378,8 +378,7 @@ def selectdata(data,
             hdf5_file_in = data._get_backing_hdf5_file_handle()
             hdf5_file_out = out._get_backing_hdf5_file_handle()
 
-            selected_data = hdf5_file_in['/waveform'][spike_idx, :, :]
-            ds = hdf5_file_out.create_dataset('/waveform', data=selected_data)
+            ds = hdf5_file_out.create_dataset('/waveform', data=hdf5_file_in['/waveform'][spike_idx, :, :])
             out.waveform = ds
 
     # Wipe data-selection slot to not alter input object

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -380,8 +380,16 @@ def selectdata(data,
 
             # Copy the waveform dataset into the new file, spike by spike to prevent memory issues.
             ds = hdf5_file_out.create_dataset('waveform', shape=(len(spike_idx), *data.waveform.shape[1:]), dtype=data.waveform.dtype)
-            for new_idx, old_idx in enumerate(spike_idx):
-                ds[new_idx, :, :] = hdf5_file_in['/waveform'][old_idx, :, :]
+            #for new_idx, old_idx in enumerate(spike_idx):
+            #    ds[new_idx, :, :] = hdf5_file_in['/waveform'][old_idx, :, :]
+            cur_new_idx = 0
+            for tidx, old_trial_indices in enumerate(spikes_by_trial):
+                num_spikes_this_trial = len(old_trial_indices)
+                new_indices = range(cur_new_idx, cur_new_idx + num_spikes_this_trial)
+                print(f"Copying {num_spikes_this_trial} spikes (for trial {tidx}/{len(spikes_by_trial)}) {old_trial_indices} to {new_indices}")
+                assert len(old_trial_indices) == len(new_indices)
+                ds[new_indices, :, :] = hdf5_file_in['/waveform'][old_trial_indices, :, :]
+                cur_new_idx = new_indices[-1] + 1
 
             out.waveform = ds
 

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -343,8 +343,9 @@ def selectdata(data,
             spy.log("Inplace selection of SpikeData with waveform not supported for the waveform.", level="INFO")
         else:
             print(f"Data.selection is {data.selection}")
+            print(f"Data.selection.trials is {[t for t in data.selection.trials]}")
 
-    # If an in-place selection was requested we're done
+    # If an in-place selection was requested we're done.
     if inplace:
         # attach frontend parameters for replay
         data.cfg.update({'selectdata': new_cfg})

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -383,7 +383,8 @@ def selectdata(data,
             cur_new_idx = 0
             for tidx, old_trial_indices in enumerate(spikes_by_trial):
                 num_spikes_this_trial = len(old_trial_indices)
-                new_indices = range(cur_new_idx, cur_new_idx + num_spikes_this_trial)
+                #new_indices = range(cur_new_idx, cur_new_idx + num_spikes_this_trial)
+                new_indices = np.arange(cur_new_idx, cur_new_idx + num_spikes_this_trial)
                 ds[new_indices, :, :] = hdf5_file_in['/waveform'][old_trial_indices, :, :]
                 cur_new_idx = new_indices[-1] + 1
 

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -378,7 +378,11 @@ def selectdata(data,
             hdf5_file_in = data._get_backing_hdf5_file_handle()
             hdf5_file_out = out._get_backing_hdf5_file_handle()
 
-            ds = hdf5_file_out.create_dataset('/waveform', data=hdf5_file_in['/waveform'][spike_idx, :, :])
+            # Copy the waveform dataset into the new file, spike by spike to prevent memory issues.
+            ds = hdf5_file_out.create_dataset('waveform', shape=(len(spike_idx), *data.waveform.shape[1:]), dtype=data.waveform.dtype)
+            for new_idx, old_idx in enumerate(spike_idx):
+                ds[new_idx, :, :] = hdf5_file_in['/waveform'][old_idx, :, :]
+
             out.waveform = ds
 
     # Wipe data-selection slot to not alter input object

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -378,16 +378,12 @@ def selectdata(data,
             hdf5_file_in = data._get_backing_hdf5_file_handle()
             hdf5_file_out = out._get_backing_hdf5_file_handle()
 
-            # Copy the waveform dataset into the new file, spike by spike to prevent memory issues.
+            # Copy the waveform dataset into the new file, trial by trial to prevent memory issues.
             ds = hdf5_file_out.create_dataset('waveform', shape=(len(spike_idx), *data.waveform.shape[1:]), dtype=data.waveform.dtype)
-            #for new_idx, old_idx in enumerate(spike_idx):
-            #    ds[new_idx, :, :] = hdf5_file_in['/waveform'][old_idx, :, :]
             cur_new_idx = 0
             for tidx, old_trial_indices in enumerate(spikes_by_trial):
                 num_spikes_this_trial = len(old_trial_indices)
                 new_indices = range(cur_new_idx, cur_new_idx + num_spikes_this_trial)
-                print(f"Copying {num_spikes_this_trial} spikes (for trial {tidx}/{len(spikes_by_trial)}) {old_trial_indices} to {new_indices}")
-                assert len(old_trial_indices) == len(new_indices)
                 ds[new_indices, :, :] = hdf5_file_in['/waveform'][old_trial_indices, :, :]
                 cur_new_idx = new_indices[-1] + 1
 

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -383,10 +383,9 @@ def selectdata(data,
             cur_new_idx = 0
             for tidx, old_trial_indices in enumerate(spikes_by_trial):
                 num_spikes_this_trial = len(old_trial_indices)
-                #new_indices = range(cur_new_idx, cur_new_idx + num_spikes_this_trial)
-                new_indices = np.arange(cur_new_idx, cur_new_idx + num_spikes_this_trial)
+                new_indices = np.s_[cur_new_idx:cur_new_idx + num_spikes_this_trial]
                 ds[new_indices, :, :] = hdf5_file_in['/waveform'][old_trial_indices, :, :]
-                cur_new_idx = new_indices[-1] + 1
+                cur_new_idx = new_indices.stop
 
             out.waveform = ds
 

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -7,6 +7,7 @@
 import numpy as np
 
 # Local imports
+import syncopy as spy
 from syncopy.shared.tools import get_frontend_cfg, get_defaults
 from syncopy.shared.parsers import data_parser
 from syncopy.shared.errors import SPYValueError, SPYTypeError, SPYInfo, SPYWarning
@@ -336,7 +337,12 @@ def selectdata(data,
         selectDict['latency'] = window
         data.selection = selectDict
 
-    print(f"Data.selection is {data.selection}")
+    # Handle selection of waveform for SpikeData objects
+    if type(data) == spy.SpikeData and data.waveform is not None:
+        if inplace:
+            spy.log("Inplace selection of SpikeData with waveform not supported for the waveform.", level="INFO")
+        else:
+            print(f"Data.selection is {data.selection}")
 
     # If an in-place selection was requested we're done
     if inplace:

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -368,7 +368,7 @@ def selectdata(data,
     # Handle selection of waveform for SpikeData objects
     if type(data) == spy.SpikeData and data.waveform is not None:
         if inplace:
-            spy.log("Inplace selection of SpikeData with waveform not supported for the waveform.", level="INFO")
+            spy.log("Inplace selection of SpikeData with waveform not supported for the waveform.", level="WARNING")
         else:
             fauxTrials = [data._preview_trial(trlno) for trlno in data.selection.trial_ids]
             spikes_by_trial = [f.idx[0] for f in fauxTrials]

--- a/syncopy/io/save_spy_container.py
+++ b/syncopy/io/save_spy_container.py
@@ -9,6 +9,7 @@ import json
 import h5py
 import numpy as np
 from collections import OrderedDict
+import syncopy as spy
 
 # Local imports
 from syncopy.shared.filetypes import FILE_EXT
@@ -192,7 +193,11 @@ def save(out, container=None, tag=None, filename=None, overwrite=False):
         # Save each member of `_hdfFileDatasetProperties` in target HDF file
         for datasetName in out._hdfFileDatasetProperties:
             dataset = getattr(out, "_" + datasetName)
-            dat = h5f.create_dataset(datasetName, data=dataset)
+            if dataset is not None:
+                spy.log(f"Writing dataset '{datasetName}' ({len(out._hdfFileDatasetProperties)} datasets total) to HDF5 file '{dataFile}'.", level="DEBUG")
+                dat = h5f.create_dataset(datasetName, data=dataset)
+            else:
+                spy.log(f"Not writing 'None 'dataset '{datasetName}' ({len(out._hdfFileDatasetProperties)} datasets total) to HDF5 file '{dataFile}'.", level="DEBUG")
 
     # Now write trial-related information
     trl_arr = np.array(out.trialdefinition)

--- a/syncopy/statistics/summary_stats.py
+++ b/syncopy/statistics/summary_stats.py
@@ -171,12 +171,13 @@ def median(spy_data, dim, keeptrials=True, **kwargs):
 def itc(spec_data, **kwargs):
     """
     Calculates the inter trial coherence for a
-    SpectralData ``spec_data`` object, the input
+    SpectralData `spec_data` object, the input
     spectrum needs to be complex.
     The ITC of N trials is given by the length
-    of the complex mean of vectors z_i(f):
+    of the complex mean of vectors `z_i(f)`:
 
-        1/N \sum z_i / |z_i|
+    .. math::
+        1/N \sum_{i=1}^{N} z_i / |z_i|
 
     and have therefore values between 0 and 1.
     In the literature this measure is also often

--- a/syncopy/statistics/summary_stats.py
+++ b/syncopy/statistics/summary_stats.py
@@ -169,7 +169,7 @@ def median(spy_data, dim, keeptrials=True, **kwargs):
 
 @unwrap_select
 def itc(spec_data, **kwargs):
-    """
+    r"""
     Calculates the inter trial coherence for a
     SpectralData `spec_data` object, the input
     spectrum needs to be complex.

--- a/syncopy/tests/test_basedata.py
+++ b/syncopy/tests/test_basedata.py
@@ -374,7 +374,8 @@ class TestBaseData():
             # Difference in actual numerical data
             dummy3 = dummy.copy()
             for dsetName in dummy3._hdfFileDatasetProperties:
-                getattr(dummy3, dsetName)[0, 0] = -99
+                if dsetName == "data":
+                    getattr(dummy3, dsetName)[0, 0] = -99
             assert dummy3.data != dummy.data
 
             del dummy, dummy3, other

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -21,7 +21,6 @@ from syncopy.datatype.methods.selectdata import selectdata
 from syncopy.io import save, load
 from syncopy.shared.errors import SPYValueError, SPYTypeError
 from syncopy.tests.misc import construct_spy_filename, flush_local_cluster
-from syncopy.tests.test_selectdata import getSpikeData
 
 
 class TestSpikeData():
@@ -458,53 +457,32 @@ class TestEventData():
 class TestWaveform():
 
     def test_waveform_invalid_set(self):
-        """Sets invalid waveform for data: dimension mismatch"""
-        spiked = SpikeData(data=np.ones((2, 3), dtype=int), samplerate=10)
+        spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
         assert spiked.data.shape == (2, 3,)
         with pytest.raises(SPYValueError, match="wrong size waveform"):
             spiked.waveform = np.ones((3, 3), dtype=int)
 
     def test_waveform_invalid_set_emptydata(self):
-        """Tries to set waveform without any data."""
         spiked = SpikeData()
         with pytest.raises(SPYValueError, match="Please assign data first"):
             spiked.waveform = np.ones((3, 3), dtype=int)
 
     def test_waveform_valid_set(self):
-        """Sets waveform in a correct way."""
-        spiked = SpikeData(data=np.ones((2, 3), dtype=int), samplerate=10)
+        spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
         assert not spiked._is_empty()
         assert spiked.data.shape == (2, 3,)
         assert type(spiked.data) == h5py.Dataset
         assert spiked._get_backing_hdf5_file_handle() is not None
         spiked.waveform = np.ones((2, 3), dtype=int)
-        assert spiked.waveform.shape == (2, 3,)
 
     def test_waveform_valid_set_with_None(self):
-        """Sets waveform to None, which is valid."""
-        spiked = SpikeData(data=np.ones((2, 3), dtype=int), samplerate=10)
+        spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
         assert not spiked._is_empty()
         assert spiked.data.shape == (2, 3,)
+        assert type(spiked.data) == h5py.Dataset
+        assert spiked._get_backing_hdf5_file_handle() is not None
         spiked.waveform = np.ones((2, 3), dtype=int)
         spiked.waveform = None
-        assert spiked.waveform is None
-
-    def test_waveform_selection_trial(self):
-        numSpikes = 20
-        spiked = getSpikeData(nSpikes = numSpikes)
-        assert sum([s.shape[0] for s in spiked.trials]) == numSpikes
-        spiked.waveform = np.ones((numSpikes, 3), dtype=int)
-        trial0_nspikes = spiked.trials[0].shape[0]
-
-        # Select trial 0 and verify that the number of spikes is correct.
-        selection = { 'trials': [0] }
-        res = spiked.selectdata(selection)
-        assert len(res.trials) == 1
-        assert res.trials[0].shape[0] == trial0_nspikes
-
-        # Verify that the waveform is also correct.
-        assert res.waveform is not None
-        assert res.waveform.shape[0] == trial0_nspikes  # Verify selection on waveform
 
 
 

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -534,9 +534,9 @@ class TestWaveform():
         assert res.waveform.shape[0] == trial0_nspikes + trial2_nspikes  # Verify selection on waveform
 
         # Verify on data level.
-        exp_data = np.where((spiked.trialid == 0) | (spiked.trialid == 2))[0]
-        for waveform_idx in range(res.waveform.shape[0]):
-            assert np.all(res.waveform[waveform_idx, :, :] == spiked.waveform[exp_data[waveform_idx], :, :])
+        expected_data_indices = np.where((spiked.trialid == 0) | (spiked.trialid == 2))[0]
+        for spike_idx in range(res.waveform.shape[0]):
+            assert np.all(res.waveform[spike_idx, :, :] == spiked.waveform[expected_data_indices][spike_idx, :, :])
 
     def test_save_load_with_waveform(self):
         """Test saving file with waveform data."""

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -513,3 +513,9 @@ if __name__ == '__main__':
     T1 = TestSpikeData()
     T2 = TestEventData()
     T3 = TestWaveform()
+
+    numSpikes, waveform_dimsize = 20, 50
+    spiked = getSpikeData(nSpikes = numSpikes)
+    spiked.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
+    selection = { 'trials': [0] }
+    res = spiked.selectdata(selection)

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -490,10 +490,10 @@ class TestWaveform():
         assert spiked.waveform is None
 
     def test_waveform_selection_trial(self):
-        numSpikes = 20
+        numSpikes, waveform_dimsize = 20, 50
         spiked = getSpikeData(nSpikes = numSpikes)
         assert sum([s.shape[0] for s in spiked.trials]) == numSpikes
-        spiked.waveform = np.ones((numSpikes, 3), dtype=int)
+        spiked.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
         trial0_nspikes = spiked.trials[0].shape[0]
 
         # Select trial 0 and verify that the number of spikes is correct.

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -469,11 +469,13 @@ class TestWaveform():
     def test_waveform_valid_set(self):
         """Sets waveform in a correct way."""
         spiked = SpikeData(data=np.ones((2, 3), dtype=int), samplerate=10)
+
         assert not spiked._is_empty()
         assert spiked.data.shape == (2, 3,)
         assert type(spiked.data) == h5py.Dataset
         assert spiked._get_backing_hdf5_file_handle() is not None
         spiked.waveform = np.ones((2, 3), dtype=int)
+        assert "waveform" in spiked._hdfFileDatasetProperties
         assert spiked.waveform.shape == (2, 3,)
 
     def test_waveform_valid_set_with_None(self):
@@ -527,6 +529,7 @@ class TestWaveform():
         with tempfile.TemporaryDirectory() as tmpdirname:
             tmp_spy_filename = os.path.join(tmpdirname, "mywffile.spike")
             save(spiked, filename=tmp_spy_filename)
+            assert "waveform" in h5py.File(tmp_spy_filename, mode="r").keys()
             spkd2 = load(filename=tmp_spy_filename)
             assert isinstance(spkd2.waveform, h5py.Dataset), f"Expected h5py.Dataset, got {type(spkd2.waveform)}"
             assert np.array_equal(spiked.waveform[()], spkd2.waveform[()])

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -13,6 +13,7 @@ import numpy as np
 
 
 # Local imports
+import syncopy as spy
 from syncopy.datatype import AnalogData, SpikeData, EventData
 from syncopy.io import save, load
 from syncopy.shared.errors import SPYValueError, SPYTypeError
@@ -558,6 +559,22 @@ class TestWaveform():
 
             # Test that we can set waveform again after deleting it.
             spkd2.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
+
+    def test_psth_with_waveform(self):
+        """Test that the waveform does not break frontend functions, like PSTH.
+           The waveform should just be ignored, and the resulting TimeLockData
+           will of course NOT have a waveform.
+        """
+        numSpikes, waveform_dimsize = 20, 50
+        spiked = getSpikeData(nSpikes = numSpikes)
+        spiked.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
+
+        cfg = spy.StructDict()
+        cfg.binsize = 0.1
+        cfg.latency = 'maxperiod'  # frontend default
+        res = spy.spike_psth(spiked, cfg)
+        assert type(res) == spy.TimeLockData
+        assert not hasattr(res, "waveform")
 
 
 if __name__ == '__main__':

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -462,6 +462,11 @@ class TestWaveform():
         with pytest.raises(SPYValueError, match="wrong size waveform"):
             spiked.waveform = np.ones((3, 3), dtype=int)
 
+    def test_waveform_invalid_set_emptydata(self):
+        spiked = SpikeData()
+        with pytest.raises(SPYValueError, match="Please assign data first"):
+            spiked.waveform = np.ones((3, 3), dtype=int)
+
     def test_waveform_valid_set(self):
         spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
         assert not spiked._is_empty()
@@ -469,6 +474,15 @@ class TestWaveform():
         assert type(spiked.data) == h5py.Dataset
         assert spiked._get_backing_hdf5_file_handle() is not None
         spiked.waveform = np.ones((2, 3), dtype=int)
+
+    def test_waveform_valid_set_with_None(self):
+        spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
+        assert not spiked._is_empty()
+        assert spiked.data.shape == (2, 3,)
+        assert type(spiked.data) == h5py.Dataset
+        assert spiked._get_backing_hdf5_file_handle() is not None
+        spiked.waveform = np.ones((2, 3), dtype=int)
+        spiked.waveform = None
 
 
 

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -456,6 +456,12 @@ class TestEventData():
 
 class TestWaveform():
 
+    def test_waveform_invalid_set(self):
+        spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
+        assert spiked.data.shape == (2, 3,)
+        with pytest.raises(SPYValueError, match="wrong size waveform"):
+            spiked.waveform = np.ones((3, 3), dtype=int)
+
     def test_waveform_valid_set(self):
         spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
         assert not spiked._is_empty()

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -495,16 +495,18 @@ class TestWaveform():
         assert sum([s.shape[0] for s in spiked.trials]) == numSpikes
         spiked.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
         trial0_nspikes = spiked.trials[0].shape[0]
+        trial2_nspikes = spiked.trials[2].shape[0]
 
         # Select trial 0 and verify that the number of spikes is correct.
-        selection = { 'trials': [0] }
+        selection = { 'trials': [0, 2] }
         res = spiked.selectdata(selection)
-        assert len(res.trials) == 1
+        assert len(res.trials) == 2
         assert res.trials[0].shape[0] == trial0_nspikes
+        assert res.trials[1].shape[0] == trial2_nspikes
 
         # Verify that the waveform is also correct.
         assert res.waveform is not None
-        assert res.waveform.shape[0] == trial0_nspikes  # Verify selection on waveform
+        assert res.waveform.shape[0] == trial0_nspikes + trial2_nspikes  # Verify selection on waveform
 
 
 

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -467,7 +467,7 @@ class TestWaveform():
         assert not spiked._is_empty()
         assert spiked.data.shape == (2, 3,)
         assert type(spiked.data) == h5py.Dataset
-        #assert spiked._get_backing_hdf5_file_handle() is not None
+        assert spiked._get_backing_hdf5_file_handle() is not None
         spiked.waveform = np.ones((2, 3), dtype=int)
 
 

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -517,5 +517,6 @@ if __name__ == '__main__':
     numSpikes, waveform_dimsize = 20, 50
     spiked = getSpikeData(nSpikes = numSpikes)
     spiked.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
-    selection = { 'trials': [0] }
+    selection = { 'trials': [0, 2] }
+    print(f"{len(spiked.trials)} source trial shapes are: {[t.shape for t in spiked.trials]})")
     res = spiked.selectdata(selection)

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import time
 import random
+import h5py
 import pytest
 import numpy as np
 import dask.distributed as dd
@@ -453,8 +454,20 @@ class TestEventData():
         with pytest.raises(SPYValueError):
             ang_dummy.definetrial(evt_dummy, pre=pre, post=post, trigger=1)
 
+class TestWaveform():
+
+    def test_waveform_valid_set(self):
+        spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
+        assert not spiked._is_empty()
+        assert spiked.data.shape == (2, 3,)
+        assert type(spiked.data) == h5py.Dataset
+        #assert spiked._get_backing_hdf5_file_handle() is not None
+        spiked.waveform = np.ones((2, 3), dtype=int)
+
+
 
 if __name__ == '__main__':
 
     T1 = TestSpikeData()
     T2 = TestEventData()
+    T3 = TestWaveform()

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -515,10 +515,3 @@ if __name__ == '__main__':
     T1 = TestSpikeData()
     T2 = TestEventData()
     T3 = TestWaveform()
-
-    numSpikes, waveform_dimsize = 20, 50
-    spiked = getSpikeData(nSpikes = numSpikes)
-    spiked.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
-    selection = { 'trials': [0, 2] }
-    print(f"{len(spiked.trials)} source trial shapes are: {[t.shape for t in spiked.trials]})")
-    res = spiked.selectdata(selection)

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -534,11 +534,13 @@ class TestWaveform():
             assert isinstance(spkd2.waveform, h5py.Dataset), f"Expected h5py.Dataset, got {type(spkd2.waveform)}"
             assert np.array_equal(spiked.waveform[()], spkd2.waveform[()])
 
-            # Test delete/unregister.
+            # Test delete/unregister when setting to None.
             spkd2.waveform = None
             assert spkd2.waveform is None
-            #spkd2._unregister_dataset("dset_mean")
             assert "waveform" not in h5py.File(tmp_spy_filename, mode="r").keys()
+
+            # Test that we can set waveform again after deleting it.
+            spkd2.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
 
 
 if __name__ == '__main__':

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -494,21 +494,27 @@ class TestWaveform():
         spiked = getSpikeData(nSpikes = numSpikes)
         assert sum([s.shape[0] for s in spiked.trials]) == numSpikes
         spiked.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
+        for spikeidx in range(numSpikes):
+            spiked.waveform[spikeidx, :, :] = np.ones((3, waveform_dimsize), dtype=int) * spikeidx
+
         trial0_nspikes = spiked.trials[0].shape[0]
         trial2_nspikes = spiked.trials[2].shape[0]
 
-        # Select trial 0 and verify that the number of spikes is correct.
+        # Select 2 trials and verify that the number of spikes is correct.
         selection = { 'trials': [0, 2] }
         res = spiked.selectdata(selection)
         assert len(res.trials) == 2
         assert res.trials[0].shape[0] == trial0_nspikes
         assert res.trials[1].shape[0] == trial2_nspikes
 
-        # Verify that the waveform is also correct.
+        # Verify that the waveform selection is also correct.
         assert res.waveform is not None
         assert res.waveform.shape[0] == trial0_nspikes + trial2_nspikes  # Verify selection on waveform
 
-
+        # Verify on data level.
+        exp_data = np.where((spiked.trialid == 0) | (spiked.trialid == 2))[0]
+        for waveform_idx in range(res.waveform.shape[0]):
+            assert np.all(res.waveform[waveform_idx, :, :] == spiked.waveform[exp_data[waveform_idx], :, :])
 
 if __name__ == '__main__':
 

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -466,6 +466,12 @@ class TestWaveform():
         with pytest.raises(SPYValueError, match="Please assign data first"):
             spiked.waveform = np.ones((3, 3), dtype=int)
 
+    def test_waveform_invalid_set_1dim(self):
+        """Tries to set waveform with data that has ndim=1."""
+        spiked = SpikeData(data=np.ones((2, 3), dtype=int), samplerate=10)
+        with pytest.raises(SPYValueError, match="waveform data with at least 2 dimensions"):
+            spiked.waveform = np.ones((3), dtype=int)
+
     def test_waveform_valid_set(self):
         """Sets waveform in a correct way."""
         spiked = SpikeData(data=np.ones((2, 3), dtype=int), samplerate=10)

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -21,6 +21,7 @@ from syncopy.datatype.methods.selectdata import selectdata
 from syncopy.io import save, load
 from syncopy.shared.errors import SPYValueError, SPYTypeError
 from syncopy.tests.misc import construct_spy_filename, flush_local_cluster
+from syncopy.tests.test_selectdata import getSpikeData
 
 
 class TestSpikeData():
@@ -457,32 +458,53 @@ class TestEventData():
 class TestWaveform():
 
     def test_waveform_invalid_set(self):
-        spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
+        """Sets invalid waveform for data: dimension mismatch"""
+        spiked = SpikeData(data=np.ones((2, 3), dtype=int), samplerate=10)
         assert spiked.data.shape == (2, 3,)
         with pytest.raises(SPYValueError, match="wrong size waveform"):
             spiked.waveform = np.ones((3, 3), dtype=int)
 
     def test_waveform_invalid_set_emptydata(self):
+        """Tries to set waveform without any data."""
         spiked = SpikeData()
         with pytest.raises(SPYValueError, match="Please assign data first"):
             spiked.waveform = np.ones((3, 3), dtype=int)
 
     def test_waveform_valid_set(self):
-        spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
+        """Sets waveform in a correct way."""
+        spiked = SpikeData(data=np.ones((2, 3), dtype=int), samplerate=10)
         assert not spiked._is_empty()
         assert spiked.data.shape == (2, 3,)
         assert type(spiked.data) == h5py.Dataset
         assert spiked._get_backing_hdf5_file_handle() is not None
         spiked.waveform = np.ones((2, 3), dtype=int)
+        assert spiked.waveform.shape == (2, 3,)
 
     def test_waveform_valid_set_with_None(self):
-        spiked = SpikeData(data=4  * np.ones((2, 3), dtype=int), samplerate=10)
+        """Sets waveform to None, which is valid."""
+        spiked = SpikeData(data=np.ones((2, 3), dtype=int), samplerate=10)
         assert not spiked._is_empty()
         assert spiked.data.shape == (2, 3,)
-        assert type(spiked.data) == h5py.Dataset
-        assert spiked._get_backing_hdf5_file_handle() is not None
         spiked.waveform = np.ones((2, 3), dtype=int)
         spiked.waveform = None
+        assert spiked.waveform is None
+
+    def test_waveform_selection_trial(self):
+        numSpikes = 20
+        spiked = getSpikeData(nSpikes = numSpikes)
+        assert sum([s.shape[0] for s in spiked.trials]) == numSpikes
+        spiked.waveform = np.ones((numSpikes, 3), dtype=int)
+        trial0_nspikes = spiked.trials[0].shape[0]
+
+        # Select trial 0 and verify that the number of spikes is correct.
+        selection = { 'trials': [0] }
+        res = spiked.selectdata(selection)
+        assert len(res.trials) == 1
+        assert res.trials[0].shape[0] == trial0_nspikes
+
+        # Verify that the waveform is also correct.
+        assert res.waveform is not None
+        assert res.waveform.shape[0] == trial0_nspikes  # Verify selection on waveform
 
 
 

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -361,28 +361,27 @@ class TestCrossSpectralSelections:
                 spy.selectdata(self.csd_data, sel_kw)
 
 
-def getSpikeData(nChannels = 10, nTrials = 5, samplerate = 1.0, nSpikes = 20):
-        T_max = 2 * nSpikes   # in samples, not seconds!
-        nSamples = T_max / nTrials
-        rng = np.random.default_rng(42)
-
-        data = np.vstack([np.sort(rng.choice(range(T_max), size=nSpikes)),
-                        rng.choice(np.arange(0, nChannels), size=nSpikes),
-                        rng.choice(nChannels // 2, size=nSpikes)]).T
-
-        trldef = np.vstack([np.arange(0, T_max, nSamples),
-                            np.arange(0, T_max, nSamples) + nSamples,
-                            np.ones(nTrials) * -2]).T
-
-        return(spy.SpikeData(data=data,
-                               samplerate=samplerate,
-                               trialdefinition=trldef))
-
-
 class TestSpikeSelections:
 
+    nChannels = 10
+    nTrials = 5
+    samplerate = 1.0
+    nSpikes = 20
+    T_max = 2 * nSpikes   # in samples, not seconds!
+    nSamples = T_max / nTrials
+    rng = np.random.default_rng(42)
 
-    spike_data = getSpikeData()
+    data = np.vstack([np.sort(rng.choice(range(T_max), size=nSpikes)),
+                      rng.choice(np.arange(0, nChannels), size=nSpikes),
+                      rng.choice(nChannels // 2, size=nSpikes)]).T
+
+    trldef = np.vstack([np.arange(0, T_max, nSamples),
+                        np.arange(0, T_max, nSamples) + nSamples,
+                        np.ones(nTrials) * -2]).T
+
+    spike_data = spy.SpikeData(data=data,
+                               samplerate=samplerate,
+                               trialdefinition=trldef)
 
     def test_spike_selection(self):
 

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -361,27 +361,28 @@ class TestCrossSpectralSelections:
                 spy.selectdata(self.csd_data, sel_kw)
 
 
+def getSpikeData(nChannels = 10, nTrials = 5, samplerate = 1.0, nSpikes = 20):
+        T_max = 2 * nSpikes   # in samples, not seconds!
+        nSamples = T_max / nTrials
+        rng = np.random.default_rng(42)
+
+        data = np.vstack([np.sort(rng.choice(range(T_max), size=nSpikes)),
+                        rng.choice(np.arange(0, nChannels), size=nSpikes),
+                        rng.choice(nChannels // 2, size=nSpikes)]).T
+
+        trldef = np.vstack([np.arange(0, T_max, nSamples),
+                            np.arange(0, T_max, nSamples) + nSamples,
+                            np.ones(nTrials) * -2]).T
+
+        return(spy.SpikeData(data=data,
+                               samplerate=samplerate,
+                               trialdefinition=trldef))
+
+
 class TestSpikeSelections:
 
-    nChannels = 10
-    nTrials = 5
-    samplerate = 1.0
-    nSpikes = 20
-    T_max = 2 * nSpikes   # in samples, not seconds!
-    nSamples = T_max / nTrials
-    rng = np.random.default_rng(42)
 
-    data = np.vstack([np.sort(rng.choice(range(T_max), size=nSpikes)),
-                      rng.choice(np.arange(0, nChannels), size=nSpikes),
-                      rng.choice(nChannels // 2, size=nSpikes)]).T
-
-    trldef = np.vstack([np.arange(0, T_max, nSamples),
-                        np.arange(0, T_max, nSamples) + nSamples,
-                        np.ones(nTrials) * -2]).T
-
-    spike_data = spy.SpikeData(data=data,
-                               samplerate=samplerate,
-                               trialdefinition=trldef)
+    spike_data = getSpikeData()
 
     def test_spike_selection(self):
 


### PR DESCRIPTION
Changes Summary
----------------
- Introduces a new dataset named `waveform` for `SpikeData` instances, see #238
- Selecting data on the main dataset automatically selects the waveforms/raw data for the appropriate spikes. (Makes no sense for in-place selections).
- Can save and load SpikeData including a wavefrom dataset.

Limitations:
- We expect the waveform dataset to have same size as the main `data` dataset for dimensions 1 to 2. It can have a 3rd dim.


Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
