### PR TITLE
438 check workers available causes execution to hang

### DIFF
--- a/syncopy/shared/dask_helpers.py
+++ b/syncopy/shared/dask_helpers.py
@@ -6,8 +6,9 @@
 import subprocess
 from time import sleep
 
-# Syncopy import
+# Syncopy imports
 from syncopy.shared.errors import SPYWarning, SPYInfo
+from .log import get_logger
 
 
 def check_slurm_available():
@@ -31,20 +32,39 @@ def check_slurm_available():
     return has_slurm
 
 
-def check_workers_available(cluster):
+def check_workers_available(client, timeout=120):
     """
-    Tries to see the Dask workers and waits
-    until all requested workers are available
+    Checks for available (alive) Dask workers and waits max `timeout` seconds
+    until at least a fraction of the workers is available.
+
+    The minimum number of workers to be waited on depends
+    on the total number of requested workers, and scales with:
+
+        minWorkers = totalWorkers^0.7
+
+    Meaning for 10 ``totalWorkers``, at least 5 have to be available,
+    wheareas for 100 ``totalWorkers`` only 25 have to be available.
     """
 
-    totalWorkers = len(cluster.requested)    
-    sec = 0
-    workers = cluster.scheduler_info['workers']
+    logger = get_logger()
+    totalWorkers = len(client.cluster.requested)
+    minWorkers = int(totalWorkers**0.7)
 
-    while len(workers) != totalWorkers:
-        SPYInfo(f"{len(workers)}/{totalWorkers} workers available, waiting.. {sec}s")
-        sleep(1)
-        sec += 2
-        workers = cluster.scheduler_info['workers']
+    # dictionary of workers
+    workers = client.cluster.scheduler_info['workers']
+
+    # some small initial wait
+    sleep(.25)
+
+    if len(workers) < minWorkers:
+        logger.important(f"waiting for at least {minWorkers}/{totalWorkers} workers being available, timeout after {timeout} seconds..")
+    client.wait_for_workers(minWorkers, timeout=timeout)
+
     # wait a little more to get consistent client print out
-    sleep(1)
+    sleep(.25)
+
+    if len(workers) != totalWorkers:
+        logger.important(f"{len(workers)}/{totalWorkers} workers available, starting computation..")
+
+    # wait a little more to get consistent client print out
+    sleep(.25)


### PR DESCRIPTION
Changes Summary
----------------
- branch off if `acme` is around earlier, and let it handle all parallel issues
- improved own dask interface: wait only for a **single worker** 


Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
