### PR TITLE
201 implement ppc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased WIP
 
 ### NEW
+- add PPC connectivity measure
 - add Jackknifing for coherence and Granger analysis
 - add logging functionality and respective developer documentation, #208
 

--- a/syncopy/connectivity/ST_compRoutines.py
+++ b/syncopy/connectivity/ST_compRoutines.py
@@ -120,12 +120,7 @@ class SpectralDyadicProduct(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
-        # time dependent coherence needs SpectralData input
-        if 'Spectral' in data.__class__.__name__:
-            time_axis = np.any(np.diff(data.trialdefinition)[:,0] != 1)
-        else:
-            time_axis = False
-
+        time_axis = np.any(np.diff(data.trialdefinition)[:,0] != 1)
         propagate_properties(data, out, self.keeptrials, time_axis)
         out.freq = data.freq
 
@@ -215,8 +210,8 @@ def ppc_column_cF(cross_spectrum,
 class PPC_column(ComputationalRoutine):
 
     """
-    Compute class that computes the dotproduct between nTrials-1 trial pairs by
-    streaming as usual through all trials available, and pairing it with one
+    Compute class that computes the dotproduct between nTrials-1 cross-spectral trial pairs
+    by streaming as usual through all trials available, and pairing it with one
     fixed 2nd trial (controlled by `trl2_idx`).
 
     Sub-class of :class:`~syncopy.shared.computational_routine.ComputationalRoutine`,
@@ -235,8 +230,13 @@ class PPC_column(ComputationalRoutine):
 
     def process_metadata(self, data, out):
 
+        time_axis = np.any(np.diff(data.trialdefinition)[:, 0] != 1)
+
+        propagate_properties(data, out, self.keeptrials, time_axis)
+        out.freq = data.freq
+
         # same data type, so trivial propagation
-        propagate_properties(data, out, self.keeptrials)
+        propagate_properties(data, out, self.keeptrials, time_axis)
 
 
 

--- a/syncopy/connectivity/connectivity_analysis.py
+++ b/syncopy/connectivity/connectivity_analysis.py
@@ -88,7 +88,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         * **nTaper** : (optional) number of orthogonal tapers for slepian tapers
         * **pad**: either pad to an absolute length in seconds or set to `'nextpow2'`
 
-    "ppc" : Pairwise phase consistency, [Vinck2010]_
+    "ppc" : Pairwise phase consistency, see [Vinck2010]_
         Computes the PPC phase locking index for all channel combinations
 
         output : real ppc spectrum
@@ -262,7 +262,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                 caller='connectivityanalysis')
         jackknife = False
 
-    # output selection is only valid for coherence
+    # output seettings are only relevant for coherence
     if method != 'coh' and output != defaults['output']:
         msg = f"Setting `output` for method {method} has not effect!"
         SPYWarning(msg)
@@ -328,8 +328,9 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         # hard coded as class attribute
         st_dimord = CrossCovariance.dimord
 
+    # all these methods need the single trial cross spectra
+    # we just have to sort out if we need an mtmfft first
     elif method in ['csd', 'coh', 'ppc', 'granger']:
-        # all these methods need the single trial cross spectra
         nTrials = len(data.trials)
         if nTrials == 1:
             lgl = "multi-trial input data, spectral connectivity measures critically depend on trial averaging!"
@@ -392,7 +393,8 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         # spectral analysis only possible with AnalogData
         if isinstance(data, AnalogData):
             besides = ['taper', 'tapsmofrq', 'nTaper']
-
+        else:
+            besides = None
         check_effective_parameters(PPC_column, defaults, lcls, besides=besides)
 
         # this needs to be treated differently, as we need repeated
@@ -413,6 +415,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                                           nIter=100,
                                           cond_max=1e4
                                           )
+    # here the single trial spectra are the final result
     elif method == 'csd':
         av_compRoutine = None
 
@@ -530,7 +533,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
     # attach frontend parameters for replay
     new_cfg.update({'output': output})
     out.cfg.update({'connectivityanalysis': new_cfg})
-            
+
     return out
 
 

--- a/syncopy/connectivity/connectivity_analysis.py
+++ b/syncopy/connectivity/connectivity_analysis.py
@@ -357,7 +357,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
         elif isinstance(data, SpectralData):
             # cross-spectra need complex input spectra
             if not np.issubdtype(data.data.dtype, np.complexfloating):
-                lgl = "complex valued spectra, set `output='fourier` in spy.freqanalysis!"
+                lgl = "complex valued spectra, set `output='fourier'` in spy.freqanalysis!"
                 act = "real valued spectral data"
                 raise SPYValueError(lgl, 'data', act)
 

--- a/syncopy/connectivity/connectivity_analysis.py
+++ b/syncopy/connectivity/connectivity_analysis.py
@@ -262,7 +262,7 @@ def connectivityanalysis(data, method="coh", keeptrials=False, output="abs",
                 caller='connectivityanalysis')
         jackknife = False
 
-    # output seettings are only relevant for coherence
+    # output settings are only relevant for coherence
     if method != 'coh' and output != defaults['output']:
         msg = f"Setting `output` for method {method} has not effect!"
         SPYWarning(msg)

--- a/syncopy/plotting/helpers.py
+++ b/syncopy/plotting/helpers.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+#
+# Helpers  to generate correct data, labels etc. for the plots
+# from Syncopy dataypes
+#
+
+# Builtin/3rd party package imports
+import numpy as np
+from copy import deepcopy
+import re
+import functools
+
+
+def revert_selection(plotter):
+
+    """
+    To extract 'meta-information' like time and freq axis
+    for a particular plot we use (implicit from the users
+    perspective) selections. To return to a clean slate
+    we revert/delete it afterwards.
+
+    All plotting routines must have `data` as 1st argument!
+    """
+    @functools.wraps(plotter)
+    def wrapper_plot(data, *args, **kwargs):
+
+        # to restore
+        select_backup = None if data.selection is None else deepcopy(data.selection.select)
+
+        res = plotter(data, *args, **kwargs)
+
+        # restore initial selection or wipe
+        if select_backup:
+            data.selectdata(select_backup, inplace=True)
+        else:
+            data.selection = None
+
+        return res
+
+    return wrapper_plot
+
+
+def parse_foi(dataobject, show_kwargs):
+
+    """
+    Create the frequency axis belonging to a foi/foilim
+    selection
+
+    Parameters
+    ----------
+    dataobject : one derived from :class:`~syncopy.datatype.base_data`
+        Syncopy datatype instance, needs to have a `freq` property
+    show_kwargs : dict
+        The keywords provided to the `selectdata` method
+    """
+
+    # apply the selection
+    dataobject.selectdata(inplace=True, **show_kwargs)
+
+    idx = dataobject.selection.freq
+    # index selection, only one `freq` for all trials
+    freq = dataobject.freq[idx]
+
+    return freq
+
+
+def parse_toi(dataobject, trl, show_kwargs):
+
+    """
+    Create the (multiple) time axis belonging to a toi/toilim
+    selection
+
+    Parameters
+    ----------
+    dataobject : one derived from :class:`~syncopy.datatype.base_data`
+        Syncopy datatype instance, needs to have a `time` property
+    trl : int
+        The index of the selected trial to plot
+    show_kwargs : dict
+        The keywords provided to the `selectdata` method
+    """
+
+    # apply the selection
+    dataobject.selectdata(inplace=True, **show_kwargs)
+
+    # still have to index the only and single trial
+    idx = dataobject.selection.time[0]
+
+    # index selection, again the single trial
+    time = dataobject.time[trl][idx]
+
+    return time
+
+
+def parse_channel(dataobject, show_kwargs):
+
+    """
+    Create the labels from a channel
+    selection
+
+    Parameters
+    ----------
+    dataobject : one derived from :class:`~syncopy.datatype.base_data`
+        Syncopy datatype instance, needs to have a `channel` property
+    show_kwargs : dict
+        The keywords provided to the `selectdata` method
+
+    Returns
+    -------
+    labels : str or list
+        Depending on the channel selection returns
+        a list of str for multiple channels or a single
+        str for a single channel selection.
+    """
+
+    # apply selection
+    dataobject.selectdata(inplace=True, **show_kwargs)
+
+    # get channel labels
+    idx = dataobject.selection.channel
+    labels = dataobject.channel[idx]
+
+    # make sure a single string is returned
+    # if only one channel is selected
+    if np.size(labels) == 1 and np.ndim(labels) != 0:
+        labels = labels[0]
+
+    return labels
+
+
+def shift_multichan(data_y):
+
+    if data_y.ndim > 1:
+        # shift 0-line for next channel
+        # above max of prev- min of current
+        offsets = data_y.max(axis=0)[:-1]
+        offsets -= data_y.min(axis=0)[1:]
+        offsets = np.cumsum(np.r_[0, offsets] * 1.1)
+    else:
+        offsets = 0
+
+    return offsets
+
+
+def get_method(dataobject, frontend_name):
+
+    """
+    Returns the method string from
+    the cfg of a Syncopy data object
+    """
+
+    cfg_entry = dataobject.cfg[frontend_name]
+    return cfg_entry.get('method')
+
+
+def get_output(dataobject, frontend_name):
+
+    """
+    Returns the output string from
+    the cfg of a Syncopy data object
+    """
+
+    cfg_entry = dataobject.cfg[frontend_name]
+    return cfg_entry.get('output')
+
+
+def calc_multi_layout(nAx):
+
+    """
+    Given the total numbers of
+    axes `nAx` create the nrows, ncols
+    layout. In case of `nAx` being prime,
+    augment by 1 to rather leave an
+    empty plot than to have say a (17, 1) layout..
+    """
+
+    # This works as well as long
+    # as `nAx` isn't prime :]
+    # so we have to augment by 1 if that's the case
+    if nAx % 2 != 0:
+        ncols = int(np.sqrt(nAx))  # this is max pltConfig["mMaxYaxes"]
+        nrows = ncols
+        while(ncols * nrows < nAx):
+            ncols += 1
+            nrows = int(nAx / ncols)
+        # nAx was prime and too big
+        # for one plotting row
+        if ncols == nAx and nAx > 4:
+            nAx += 1
+    # no elif to capture possibly incremented nAx
+    if nAx % 2 == 0 and nAx > 2:
+        nrows = int(np.sqrt(nAx))  # this is max pltConfig["mMaxYaxes"]
+        ncols = nAx // nrows
+        while(ncols * nrows < nAx):
+            nrows -= 1
+            ncols = int(nAx / nrows)
+    # just two axes
+    elif nAx == 2:
+        nrows, ncols = 1, 2
+
+    return nrows, ncols
+
+
+def check_if_time_freq(data):
+    """
+    Looks into the first column of the trialdefinition
+    to determine if there is a real time axis, or it is
+    just trial stacking.
+    """
+    is_tf = np.any(np.diff(data.trialdefinition)[:, 0] != 1)
+
+    return is_tf

--- a/syncopy/plotting/mp_plotting.py
+++ b/syncopy/plotting/mp_plotting.py
@@ -13,7 +13,7 @@ from numbers import Number
 from syncopy import __plt__
 from syncopy.shared.errors import SPYWarning, SPYValueError
 from syncopy.plotting import _plotting
-from syncopy.plotting import _helpers as plot_helpers
+from syncopy.plotting import helpers as plot_helpers
 from syncopy.plotting.config import pltErrMsg, pltConfig
 
 
@@ -170,7 +170,7 @@ def plot_SpectralData(data, **show_kwargs):
 
         # get the data to plot
         data_x = plot_helpers.parse_foi(data, show_kwargs)
-        output = plot_helpers.get_output(data)
+        output = plot_helpers.get_output(data, 'freqanalysis')
 
         # only log10 the absolute squared spectra
         if output == 'pow':
@@ -240,8 +240,8 @@ def plot_CrossSpectralData(data, **show_kwargs):
     chi, chj = show_kwargs['channel_i'], show_kwargs['channel_j']
 
     # what data do we have?
-    method = plot_helpers.get_method(data)
-    output = plot_helpers.get_output(data)
+    method = plot_helpers.get_method(data, 'connectivityanalysis')
+    output = plot_helpers.get_output(data, 'connectivityanalysis')
 
     if method == 'granger':
         xlabel = 'frequency (Hz)'

--- a/syncopy/plotting/sp_plotting.py
+++ b/syncopy/plotting/sp_plotting.py
@@ -13,7 +13,7 @@ from numbers import Number
 from syncopy import __plt__
 from syncopy.shared.errors import SPYWarning, SPYValueError
 from syncopy.plotting import _plotting
-from syncopy.plotting import _helpers as plot_helpers
+from syncopy.plotting import helpers as plot_helpers
 from syncopy.plotting.config import pltErrMsg, pltConfig
 
 
@@ -166,7 +166,7 @@ def plot_SpectralData(data, logscale=True, **show_kwargs):
             labels = channels
         # get the data to plot
         data_x = plot_helpers.parse_foi(data, show_kwargs)
-        output = plot_helpers.get_output(data)
+        output = plot_helpers.get_output(data, 'freqanalysis')
 
         # only log10 the absolute squared spectra
         if output == 'pow' and logscale:
@@ -249,8 +249,8 @@ def plot_CrossSpectralData(data, **show_kwargs):
         chj_label = chj
 
     # what data do we have?
-    method = plot_helpers.get_method(data)
-    output = plot_helpers.get_output(data)
+    method = plot_helpers.get_method(data, 'connectivityanalysis')
+    output = plot_helpers.get_output(data, 'connectivityanalysis')
 
     if method == 'granger':
         xlabel = 'frequency (Hz)'
@@ -260,6 +260,11 @@ def plot_CrossSpectralData(data, **show_kwargs):
     elif method == 'coh':
         xlabel = 'frequency (Hz)'
         ylabel = f'{output} coherence'
+        label = rf"{chi_label} - {chj_label}"
+        data_x = plot_helpers.parse_foi(data, show_kwargs)
+    elif method == 'ppc':
+        xlabel = 'frequency (Hz)'
+        ylabel = 'PPC'
         label = rf"{chi_label} - {chj_label}"
         data_x = plot_helpers.parse_foi(data, show_kwargs)
     elif method == 'corr':
@@ -274,7 +279,7 @@ def plot_CrossSpectralData(data, **show_kwargs):
     is_tf = plot_helpers.check_if_time_freq(data)
 
     # time dependent coherence
-    if method == 'coh' and is_tf:
+    if method in ['coh', 'ppc'] and is_tf:
         # here we always need a new axes
         fig, ax = _plotting.mk_img_figax()
 

--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -1124,7 +1124,7 @@ def propagate_properties(in_data, out_data, keeptrials=True, time_axis=False):
             out_data.trialdefinition = in_data.selection.trialdefinition
         else:
             # trial average requires equal length trials, so just copy the 1st
-            out_data.trialsdefinition = in_data.trialdefinition[0, :][None, :]
+            out_data.trialdefinition = in_data.trialdefinition[0, :][None, :]
 
         out_data.samplerate = in_data.samplerate
         if selection_cleanup:

--- a/syncopy/statistics/summary_stats.py
+++ b/syncopy/statistics/summary_stats.py
@@ -453,7 +453,7 @@ def _trial_var(in_data, out_arr):
 
 def _trial_circ_average(in_data, out_arr):
     """
-    Sequential complex average, can be used for
+    Sequential complex average on the unit circle, can be used for
     inter trial coherence (order parameter) or mean phase estimation.
     Shape checking and dealing with selections is done in `_trial_statistics`.
 
@@ -467,7 +467,7 @@ def _trial_circ_average(in_data, out_arr):
 
     trials = in_data.selection.trials
     for trl in trials:
-        # add cartesian unit vectors
+        # add complex unit vectors
         out_arr += trl / np.abs(trl)
 
     # normalize

--- a/syncopy/statistics/summary_stats.py
+++ b/syncopy/statistics/summary_stats.py
@@ -214,6 +214,8 @@ def itc(spec_data, **kwargs):
     # takes care of remaining checks
     res = _trial_statistics(spec_data, operation='itc')
     write_log(spec_data, res, kwargs, op_name='itc')
+    # attach cfg
+    res.cfg.update(spec_data.cfg)
     return res
 
 
@@ -316,6 +318,9 @@ def _statistics(spy_data, operation, dim, keeptrials=True, **kwargs):
     if hasattr(spy_data.selection, '_cleanup'):
         spy_data.cfg.pop('selectdata')
         spy_data.selection = None
+
+    # re-attach config
+    out.cfg.update(spy_data.cfg)
 
     return out
 

--- a/syncopy/statistics/summary_stats.py
+++ b/syncopy/statistics/summary_stats.py
@@ -342,8 +342,8 @@ def _trial_statistics(in_data, operation='mean'):
         in_data.selection._cleanup = True
 
     nTrials = len(in_data.selection.trials)
-    if nTrials <= 1:
-        lgl = "at least 2 trials"
+    if nTrials < 1:
+        lgl = "at least 1 trial"
         act = f"got {nTrials} trials"
         raise SPYValueError(lgl, 'in_data', act)
 

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -309,8 +309,8 @@ class TestCoherence:
 
     def test_timedep_coh(self):
         """
-        stack together different phase diffusing signals
-        with increasing diffusion strength to emulate non-stationarity
+        Time dependent coherence of phase diffusing signals.
+        Starting from a common phase, they'll decorrelate over time.
         """
 
         # 20Hz band has strong diffusion so coherence
@@ -480,8 +480,8 @@ class TestCoherence:
                      cfg=get_defaults(cafunc))
 
     @skip_low_mem
-    def test_parallel(self):
-        check_parallel(TestCoherence())
+    def test_coh_parallel(self):
+        check_parallel(self)
 
     def test_coh_padding(self):
 
@@ -555,8 +555,8 @@ class TestCSD:
         assert cross_spec.data.shape != self.spec.data.shape
 
     @skip_low_mem
-    def test_parallel(self):
-        check_parallel(TestCSD())
+    def test_csd_parallel(self):
+        check_parallel(self)
 
     def test_csd_input(self):
         assert isinstance(self.spec, SpectralData)
@@ -707,12 +707,204 @@ class TestCorrelation:
                      cfg=get_defaults(cafunc))
 
     @skip_low_mem
-    def test_parallel(self):
-        check_parallel(TestCorrelation())
+    def test_corr_parallel(self):
+        check_parallel(self)
 
     def test_corr_polyremoval(self):
 
         call = lambda polyremoval: self.test_corr_solution(polyremoval=polyremoval)
+        helpers.run_polyremoval_test(call)
+
+
+class TestPPC:
+
+    nSamples = 1000
+    nChannels = 3
+    nTrials = 20
+    fs = 1000
+
+    # -- one harmonic with individual phase diffusion --
+
+    f1 = 20
+    # phase diffusion (1% per step) in the 20Hz band
+    s1 = synth_data.phase_diffusion(nTrials, freq=f1,
+                                    eps=.01,
+                                    nChannels=nChannels,
+                                    nSamples=nSamples,
+                                    seed=helpers.test_seed)
+    wn = synth_data.white_noise(nTrials, nChannels=nChannels, nSamples=nSamples,
+                                seed=helpers.test_seed)
+
+    # superposition
+    data = s1 + wn
+    data.samplerate = fs
+    time_span = [-1, nSamples / fs - 1]   # -1s offset
+
+    # spectral analysis
+    cfg = spy.StructDict()
+    cfg.tapsmofrq = 1.5
+    cfg.foilim = [5, 60]
+
+    spec = spy.freqanalysis(data, cfg, output='fourier', keeptapers=True)
+
+    def test_timedep_ppc(self):
+        """
+        Time dependent PPC of phase diffusing signals.
+        Starting from a common phase, they'll decorrelate over time.
+        """
+
+        # 20Hz band has strong diffusion so coherence
+        # will go down noticably over the observation time
+        test_data = self.data
+        # check number of samples
+        assert test_data.time[0].size == self.nSamples
+
+        # get time-frequency spec for the non-stationary signal
+        spec_tf = spy.freqanalysis(test_data, method='mtmconvol',
+                                   t_ftimwin=0.3, foilim=[5, 100],
+                                   output='fourier')
+
+        # compute time dependent coherence
+        ppc = cafunc(data=spec_tf, method='ppc')
+
+        # check that we have still the same time axis
+        assert np.all(ppc.time[0] == test_data.time[0])
+
+        # not exactly beautiful but it makes the point
+        ppc.singlepanelplot(channel_i=0, channel_j=1, frequency=[7, 60])
+
+        # for visual comparison to the coherence which has more bias
+        coh = cafunc(data=spec_tf, method='coh')
+
+        # plot the coherence over time just along two different frequency bands
+        ppl.figure()
+        ppc_profile20 = ppc.show(frequency=self.f1, channel_i=0, channel_j=1)
+        ppl.plot(ppc_profile20, label='20Hz')
+        ppl.plot(coh.show(frequency=20, channel_i=0, channel_j=1), ls='--',
+                 label='20Hz coherence', c='k', alpha=0.4)
+
+        # here is nothing
+        ppc_profile50 = ppc.show(frequency=50, channel_i=0, channel_j=1)
+        ppl.plot(ppc_profile50, label='50Hz')
+
+        ppl.plot(coh.show(frequency=50, channel_i=0, channel_j=1),
+                 label='50Hz coherence', c='k', alpha=0.4)
+
+        ppl.title(f'PPC(t), nTrials={self.nTrials}')
+        ppl.xlabel('samples')
+        ppl.ylabel('PPC')
+        ppl.legend()
+
+        # check that the 20 Hz band has high PPC only in the beginning
+        assert ppc_profile20.max() > 0.9
+        assert ppc_profile20.argmax() < self.nSamples / 10
+        # side band never has high PPC
+        # note that we can go lower as compared to the coherence
+        # as PPC has less bias
+        assert ppc_profile50.max() < 0.2
+
+        # check that for the sideband noise (0 true coherence) we get lower values as
+        # for the classic coherence
+        assert np.all(coh.show(frequency=50, channel_i=0, channel_j=1) > ppc_profile50)
+
+    def test_ppc_solution(self, **kwargs):
+
+        # re-run spectral analysis
+        if len(kwargs) != 0:
+            spec = spy.freqanalysis(self.data, self.cfg, output='fourier',
+                                    keeptapers=True, **kwargs)
+        else:
+            spec = self.spec
+        # sanity check
+        assert isinstance(self.data, AnalogData)
+        assert isinstance(spec, SpectralData)
+
+        res_spec = cafunc(data=spec,
+                          method='ppc',
+                          **kwargs)
+
+        # needs same cfg for spectral analysis
+        res_ad = cafunc(data=self.data,
+                        method='ppc',
+                        cfg=self.cfg,
+                        **kwargs)
+
+        # same results on all channels and freqs
+        # irrespective of AnalogData or SpectralData input
+        assert np.allclose(res_spec.trials[0], res_ad.trials[0])
+
+        for res in [res_spec, res_ad]:
+            # coherence at the harmonic frequencies
+            idx_f1 = np.argmin(res.freq < self.f1)
+            peak_f1 = res.data[0, idx_f1, 0, 1]
+
+            assert peak_f1 > 0.25
+            # check that highest coherence is at the
+            # harmonic frequency
+            # assert res.show(channel_i=0, channel_j=1).argmax() == idx_f1
+
+            # check that 5Hz away from the harmonics there
+            # is low PPC
+            null_idx = (res.freq < self.f1 - 5) | (res.freq > self.f1 + 5)
+            assert np.all(res.data[0, null_idx, 0, 1] < 0.2)
+
+            if len(kwargs) == 0:
+                res.singlepanelplot(channel_i=0, channel_j=1)
+
+    def test_ppc_selections(self):
+
+        sel_dct = helpers.mk_selection_dicts(self.nTrials,
+                                             self.nChannels,
+                                             *self.time_span)[0]
+
+        result = cafunc(self.data, self.cfg, method='coh', select=sel_dct)
+
+        # re-run spectral analysis with selection
+        spec = spy.freqanalysis(self.data, self.cfg, output='fourier',
+                                keeptapers=True, select=sel_dct)
+
+        result_spec = cafunc(spec, method='coh')
+
+        # check here just for finiteness and positivity
+        assert np.all(np.isfinite(result.data))
+        assert np.all(result.data[0, ...] >= -1e-10)
+
+        # same results
+        assert np.allclose(result.trials[0], result_spec.trials[0], atol=1e-3)
+
+        # test one final selection into a result
+        # obtained via orignal SpectralData input
+        sel_dct.pop('latency')
+        result_ad = cafunc(self.data, self.cfg, method='ppc', select=sel_dct)
+        result_spec = cafunc(self.spec, method='ppc', select=sel_dct)
+        assert np.allclose(result_ad.trials[0], result_spec.trials[0], atol=1e-3)
+
+    def test_ppc_foi(self):
+
+        # make sure out-of-range foilim  are detected
+        with pytest.raises(SPYValueError, match='foilim'):
+            _ = cafunc(self.data, method='ppc', foilim=[-1, 70])
+
+        # make sure invalid foilim are detected
+        with pytest.raises(SPYValueError, match='foilim'):
+            _ = cafunc(self.data, method='ppc', foilim=[None, None])
+
+        with pytest.raises(SPYValueError, match='foilim'):
+            _ = cafunc(self.data, method='ppc', foilim='abc')
+
+    @skip_low_mem
+    def test_ppc_parallel(self):
+        check_parallel(self)
+
+    def test_ppc_padding(self):
+
+        pad_length = 2   # seconds
+        call = lambda pad: self.test_ppc_solution(pad=pad)
+        helpers.run_padding_test(call, pad_length)
+
+    def test_ppc_polyremoval(self):
+
+        call = lambda polyremoval: self.test_ppc_solution(polyremoval=polyremoval)
         helpers.run_polyremoval_test(call)
 
 
@@ -782,3 +974,4 @@ if __name__ == '__main__':
     T3 = TestCorrelation()
     T4 = TestSpectralInput()
     T5 = TestCSD()
+    T6 = TestPPC()


### PR DESCRIPTION
Changes Summary
----------------
- Added PPC connectivity measure, works also time-dependent (with tf spectra as input)
- Computation is done by outer loop over repeated CR inits and calls as we need N(N-1) dot products
- reasoning is that we saturate parallel processing ressources already by the number of trials (single CR `.compute`), hence additional parallelization makes no real sense

Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
