### PR TITLE
444 allow unequal trials for load ft raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - add waveform extra dataset to DiscreteData to store raw data, #238
 
 ### CHANGED
+- support unequal trial sizes for `load_ft_raw`
 - major performance improvements for DiscreteData #403 #418, #424
 
 ### Fixed

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -716,7 +716,7 @@ class BaseData(ABC):
     @sampleinfo.setter
     def sampleinfo(self, sinfo):
         raise SPYError(
-            "Cannot set sampleinfo. Use `BaseData._trialdefinition` instead."
+            "Cannot set sampleinfo. Use `BaseData.trialdefinition` instead."
         )
 
     @property
@@ -772,7 +772,7 @@ class BaseData(ABC):
     @trialinfo.setter
     def trialinfo(self, trl):
         raise SPYError(
-            "Cannot set trialinfo. Use `BaseData._trialdefinition` or `syncopy.definetrial` instead."
+            "Cannot set trialinfo. Use `BaseData.trialdefinition` or `syncopy.definetrial` instead."
         )
 
     # Helper function that grabs a single trial

--- a/syncopy/datatype/methods/definetrial.py
+++ b/syncopy/datatype/methods/definetrial.py
@@ -93,10 +93,7 @@ def definetrial(obj, trialdefinition=None, pre=None, post=None, start=None,
                 raise exc
             evt = True
         else:
-            try:
-                array_parser(trialdefinition, varname="trialdefinition", dims=2)
-            except Exception as exc:
-                raise exc
+            array_parser(trialdefinition, varname="trialdefinition", dims=2)
 
             if any(["ContinuousData" in str(base) for base in obj.__class__.__mro__]):
                 scount = obj.data.shape[obj.dimord.index("time")]

--- a/syncopy/datatype/methods/selectdata.py
+++ b/syncopy/datatype/methods/selectdata.py
@@ -245,16 +245,21 @@ def selectdata(data,
     """
 
     # Ensure our one mandatory input is usable
-    try:
-        data_parser(data, varname="data", empty=False)
-    except Exception as exc:
-        raise exc
+    data_parser(data, varname="data", empty=False)
 
     # Vet the only inputs not checked by `Selector`
     if not isinstance(inplace, bool):
         raise SPYTypeError(inplace, varname="inplace", expected="Boolean")
     if not isinstance(clear, bool):
         raise SPYTypeError(clear, varname="clear", expected="Boolean")
+
+    # there is no `@unwrap_select` decorator in place here,
+    # a `select` dictionary must therefore be directly passed via ** unpacking:
+    # select = {'channel': [0]}; spy.selectdata(data, **select)
+    if 'select' in kwargs:
+        lgl = "unpacked selection keywords directly, try `**select`"
+        act = "`select` as explicit parameter"
+        raise SPYValueError(legal=lgl, varname="selection kwargs", actual=act)
 
     # get input arguments into cfg dict
     new_cfg = get_frontend_cfg(get_defaults(selectdata), locals(), kwargs)

--- a/syncopy/io/load_ft.py
+++ b/syncopy/io/load_ft.py
@@ -4,7 +4,6 @@
 #
 
 # Builtin/3rd party package imports
-import sys
 import re
 import h5py
 import numpy as np
@@ -12,7 +11,7 @@ from scipy import io as sio
 from tqdm import tqdm
 
 # Local imports
-from syncopy.shared.errors import SPYValueError, SPYInfo, SPYWarning, SPYTypeError
+from syncopy.shared.errors import SPYValueError, SPYInfo, SPYWarning
 from syncopy.shared.parsers import io_parser, sequence_parser, scalar_parser
 from syncopy.datatype import AnalogData
 
@@ -209,7 +208,6 @@ def load_ft_raw(filename,
         _check_req_fields(req_fields_raw, structure)
         # the AnalogData objs
         adata = struct_reader(structure)
-        thisMethod = sys._getframe().f_code.co_name.replace("_", "")
 
         # Write log-entry
         msg = f"loaded struct `{skey}` from Matlab file version {version}\n"


### PR DESCRIPTION
Changes Summary
----------------
- Allows to read in Field Trip raw data format with unequal trials 
- catching unsupported `select` keyword in `spy.selectdata`


Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
