### PR TITLE
Poetry install failing on github after poetry 1.4.1 release

### DIFF
--- a/.github/workflows/cov_test_workflow.yml
+++ b/.github/workflows/cov_test_workflow.yml
@@ -24,7 +24,7 @@ jobs:
         python-version: "3.10"
     - name: Install poetry
       run: |
-        pip install poetry
+        pip install poetry==1.4.0
     - name: Install SyNCoPy
       run: |
         poetry cache clear . --all

--- a/.github/workflows/cov_test_workflow.yml
+++ b/.github/workflows/cov_test_workflow.yml
@@ -27,6 +27,7 @@ jobs:
         pip install poetry
     - name: Install SyNCoPy
       run: |
+        poetry cache clear . --all
         poetry install
     - name: Lint with flake8
       run: |

--- a/.github/workflows/cov_test_workflow.yml
+++ b/.github/workflows/cov_test_workflow.yml
@@ -27,7 +27,6 @@ jobs:
         pip install poetry==1.4.0
     - name: Install SyNCoPy
       run: |
-        poetry cache clear . --all
         poetry install
     - name: Lint with flake8
       run: |

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ electrophysiology data-analysis in Python. We strive to achieve the following go
    makes use of available computing resources and is developed with built-in
    parallelism in mind.
 3. Syncopy is *compatible with FieldTrip*. Data and results can be loaded into
-   MATLAB and Python, parameter names and function call syntax are as similar as possible
+   MATLAB and Python, and parameter names and function call syntax are as similar as possible.
 
 Syncopy is developed at the
 `Ernst Strüngmann Institute (ESI) gGmbH for Neuroscience in Cooperation with Max Planck Society <https://www.esi-frankfurt.de/>`_


### PR DESCRIPTION
Changes Summary
----------------
Test  branch to test the CI on github. This branch only contains a minor change to the README and serves to demonstrate that something is wrong with the poetry setup on the GitHub runners. 

It also serves to mess around with the GH workflow file to fix the issue, without messing around on dev directly.

This bug could be related to [pradyunsg/sphinx-theme-builder/issues/13](https://github.com/pradyunsg/sphinx-theme-builder/issues/13). See also [poetry #7691](https://github.com/python-poetry/poetry/issues/7691)

**UPDATE:** I temporarily fixed this by pinning the poetry version to 1.4.0, it is broke since the release of poetry 1.4.1 on 2023/03/19. It may be that the real issue is a broken hash (that was not properly validated with poetry 1.4.0, but is now in 1.4.1). So the real culprit may be sphinx-theme-builder ([see their  issue 39](https://github.com/pradyunsg/sphinx-theme-builder/pull/39)), which introduces the broken hash leading to a `_WheelFileValidationError` into `pydata_sphinx_theme-0.8.1-py3-none-any.whl`, which we have as a dependency. See also the [issue 1253 of pydata-sphinx-theme](https://github.com/pydata/pydata-sphinx-theme/issues/1253).

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
