### PR TITLE
CHG: Normalize spectra independent of padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - concatenation of syncopy data objects along trials
 
 ### CHANGED
+- spectral power for `mtmfft` now independent of padding as originally intended
 - support unequal trial sizes for `load_ft_raw`
 - major performance improvements for DiscreteData #403 #418, #424
 

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -56,7 +56,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
                  taper_opt=None, tapsmofrq=None, nTaper=None, keeptapers=False,
                  toi="all", t_ftimwin=None, wavelet="Morlet", width=6, order=None,
                  order_max=None, order_min=1, c_1=3, adaptive=False,
-                 out=None, fooof_opt=None, **kwargs):
+                 out=None, fooof_opt=None, ft_compat=False, **kwargs):
     """
     Perform (time-)frequency analysis of Syncopy :class:`~syncopy.AnalogData` objects
 
@@ -179,7 +179,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
         For the default `maxperlen`, no padding is performed in case of equal
         length trials, while trials of varying lengths are padded to match the
         longest trial. If `pad` is a number all trials are padded so that `pad` indicates
-        the absolute length of all trials after padding (in seconds). For instance
+        the absolute length of all trials after padding in seconds. For instance
         ``pad = 2`` pads all trials to an absolute length of 2000 samples, if and
         only if the longest trial contains at maximum 2000 samples and the
         samplerate is 1kHz. If `pad` is `'nextpow2'` all trials are padded to the
@@ -284,6 +284,10 @@ def freqanalysis(data, method='mtmfft', output='pow',
         `FOOOF docs <https://fooof-tools.github.io/fooof/generated/fooof.FOOOF.html#fooof.FOOOF>`_
         for the meanings and the defaults.
         See the FOOOF reference [Donoghue2020]_ for details.
+    ft_compat : bool, optional
+        Set to `True` to use Field Trip's spectral normalization for FFT based methods
+        (``method='mtmfft'`` and ``method='mtmconvol'``). So spectral power is NOT
+        independent of the padding size!
 
     Returns
     -------
@@ -387,7 +391,7 @@ def freqanalysis(data, method='mtmfft', output='pow',
         raise SPYValueError(legal=lgl, varname="output", actual=output)
 
     # Parse all Boolean keyword arguments
-    for vname in ["keeptrials", "keeptapers", "demean_taper"]:
+    for vname in ["keeptrials", "keeptapers", "demean_taper", "ft_compat"]:
         if not isinstance(lcls[vname], bool):
             raise SPYTypeError(lcls[vname], varname=vname, expected="Bool")
 
@@ -605,7 +609,8 @@ def freqanalysis(data, method='mtmfft', output='pow',
             'taper': taper,
             'taper_opt': taper_opt,
             'nSamples': minSampleNum,
-            'demean_taper': demean_taper
+            'demean_taper': demean_taper,
+            'ft_compat': ft_compat
         }
 
         # Set up compute-class

--- a/syncopy/specest/mtmconvol.py
+++ b/syncopy/specest/mtmconvol.py
@@ -15,7 +15,7 @@ from ._norm_spec import _norm_taper
 
 
 def mtmconvol(data_arr, samplerate, nperseg, noverlap=None, taper="hann",
-              taper_opt={}, boundary='zeros', padded=True, detrend=False):
+              taper_opt=None, boundary='zeros', padded=True, detrend=False):
 
     """
     (Multi-)tapered short time fast Fourier transform. Returns
@@ -37,7 +37,7 @@ def mtmconvol(data_arr, samplerate, nperseg, noverlap=None, taper="hann",
     taper : str or None
         Taper function to use, one of `scipy.signal.windows`
         Set to `None` for no tapering.
-    taper_opt : dict
+    taper_opt : dict or None
         Additional keyword arguments passed to the `taper` function.
         For multi-tapering with ``taper='dpss'`` set the keys
         `'Kmax'` and `'NW'`.
@@ -90,6 +90,9 @@ def mtmconvol(data_arr, samplerate, nperseg, noverlap=None, taper="hann",
         taper = 'boxcar'
 
     taper_func = getattr(signal.windows, taper)
+
+    if taper_opt is None:
+        taper_opt = {}
 
     # this parameter mitigates the sum-to-zero problem for the odd slepians
     # as signal.stft has hardcoded scaling='spectrum'

--- a/syncopy/tests/test_specest.py
+++ b/syncopy/tests/test_specest.py
@@ -195,7 +195,7 @@ class TestMTMFFT():
         nSamples = 1000
         fsample = 500  # 2s long signal
         Ampl = 4  # amplitude
-        # 50Hz harmonic --> amplitude is Ampl^2 / 2 = 8
+        # 50Hz harmonic, spectral power is given by: Ampl^2 / 2 = 8
         signal = Ampl * np.cos(2 * np.pi * 50 * np.arange(nSamples) * 1 / fsample)
 
         # single signal/channel is enough


### PR DESCRIPTION
Changes Summary
----------------

- this implements Pascal's original power normalization intention: spectral power is independent of signal length/padding
- added `ft_compat` parameter for `freqanalysis --> mtmfft` to get FT behavior if needed
- no changes needed for `mtmconvol` as here the individual segments get not padded (modulo the edges)

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
