### PR TITLE
FIX: fix TestMetadataUsingFooof.test_channel_par

### DIFF
--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -607,6 +607,9 @@ class ComputationalRoutine(ABC):
         # Create HDF5 dataset of appropriate dimension
         self.preallocate_output(out, parallel_store=parallel_store)
 
+        log_dict = {} if log_dict is None else log_dict
+        log_dict["used_parallel"] = str(parallel)
+
         if parallel:
 
             # Construct list of dicts that will be passed on to workers: in the

--- a/syncopy/tests/test_metadata.py
+++ b/syncopy/tests/test_metadata.py
@@ -424,9 +424,7 @@ class TestMetadataUsingFooof():
 
         spec_dt_metadata_unnested = metadata_unnest(spec_dt.metadata)
         assert num_metadata_attrs == self.num_expected_metadata_keys
-
-        num_calls_expected = self.num_expected_metadata_keys * num_trials_fooof * calls_per_trial
-        assert len(spec_dt_metadata_unnested.keys()) == num_calls_expected
+        assert len(spec_dt_metadata_unnested.keys()) == self.num_expected_metadata_keys * num_trials_fooof * calls_per_trial
         for kv in keys_unique:
             assert kv in spec_dt_metadata_unnested.keys()
             assert isinstance(spec_dt_metadata_unnested.get(kv), (list, np.ndarray))

--- a/syncopy/tests/test_metadata.py
+++ b/syncopy/tests/test_metadata.py
@@ -395,7 +395,11 @@ class TestMetadataUsingFooof():
         spec_dt = freqanalysis(cfg, multi_chan_data, fooof_opt=fooof_opt, chan_per_worker=chan_per_worker)
 
         # How many more calls we expect due to channel parallelization.
-        calls_per_trial = int(math.ceil(num_channels / chan_per_worker))
+        used_parallel = 'used_parallel = True' in spec_dt._log
+        if used_parallel:
+            calls_per_trial = int(math.ceil(num_channels / chan_per_worker))
+        else:
+            calls_per_trial = 1
         data_size = 100
 
         # check frequency axis
@@ -420,7 +424,9 @@ class TestMetadataUsingFooof():
 
         spec_dt_metadata_unnested = metadata_unnest(spec_dt.metadata)
         assert num_metadata_attrs == self.num_expected_metadata_keys
-        assert len(spec_dt_metadata_unnested.keys()) == self.num_expected_metadata_keys * num_trials_fooof * calls_per_trial
+
+        num_calls_expected = self.num_expected_metadata_keys * num_trials_fooof * calls_per_trial
+        assert len(spec_dt_metadata_unnested.keys()) == num_calls_expected
         for kv in keys_unique:
             assert kv in spec_dt_metadata_unnested.keys()
             assert isinstance(spec_dt_metadata_unnested.get(kv), (list, np.ndarray))


### PR DESCRIPTION
Fix: Determine `TestMetadataUsingFooof.test_channel_par()` unit test expectations based on whether parallel processing was *actually used* (as opposed to *requested*).

This fixes things on the MacOS runners at ESI. On GitHub CI, this is not triggered, as the tests actually run in parallel there.

Explanation:
It turned out that the test fails if parallel computation is not actually possible on the system, i.e., you set `cfg.parallel=True`, but actually sequential computation is being used (with a warning, but the test does not know about that). I solved this by adding a `log_dict` entry `used_parallel`, which should also come in handy in other situations.



Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
