### PR TITLE
Fix win tests

### DIFF
--- a/syncopy/tests/test_attach_dataset.py
+++ b/syncopy/tests/test_attach_dataset.py
@@ -202,16 +202,6 @@ class TestAttachDataset:
         assert 'adt' not in locals()
 
         # repeat with hdf5 datasets
-        #with tempfile.TemporaryDirectory() as tdir:
-        #    file1 = h5py.File(os.path.join(tdir, "dummy1.h5"), 'w')
-        #    extra_ds1 = file1.create_dataset("d1", extra_data1.shape)
-        #    extra_ds1[()] = extra_data1
-
-        #    file2 = h5py.File(os.path.join(tdir, "dummy2.h5"), 'w')
-        #    extra_ds2 = file2.create_dataset("d2", extra_data2.shape)
-        #    extra_ds2[()] = extra_data2
-
-        # repeat with hdf5 datasets
         tfile1 = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
         tfile1.close()
         tfile2 = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
@@ -226,6 +216,11 @@ class TestAttachDataset:
 
                 some_local_func(extra_ds1, extra_ds2)
                 assert 'adt' not in locals()
+
+        tfile1.close()
+        os.unlink(tfile1.name)
+        tfile2.close()
+        os.unlink(tfile2.name)
 
     def test_attach_None_to_analog_data(self):
         """

--- a/syncopy/tests/test_attach_dataset.py
+++ b/syncopy/tests/test_attach_dataset.py
@@ -316,7 +316,6 @@ class TestAttachDataset:
 
 
         tfile0 = tempfile.NamedTemporaryFile(suffix=".spike", delete=True)
-        print(f"tfile0 is: {tfile0.name}")
         tfile0.close()
         # Test save and load.
         tmp_spy_filename = tfile0.name
@@ -329,16 +328,13 @@ class TestAttachDataset:
         spkd2._unregister_dataset("dset_mean")
         assert "dset_mean" not in h5py.File(tmp_spy_filename, mode="r").keys()
         tfile0.close()
-        #os.unlink(tfile0.name)
 
         spkd = get_spike_data()
 
         # repeat with hdf5 datasets
         tfile1 = tempfile.NamedTemporaryFile(suffix=".spike", delete=False)
-        print(f"tfile1 is: {tfile1.name}")
         tfile1.close()
         tfile2 = tempfile.NamedTemporaryFile(suffix=".spike", delete=True)
-        print(f"tfile2 is: {tfile2.name}")
         tfile2.close()
 
         file1 = h5py.File(tfile1.name, 'w')
@@ -358,10 +354,6 @@ class TestAttachDataset:
         spkd2._unregister_dataset("dset_mean")
         tfile2.close()
         assert "dset_mean" not in h5py.File(tmp_spy_filename, mode="r").keys()
-
-        #tfile1.close()
-        #tfile2.close()
-
 
 
 if __name__ == '__main__':

--- a/syncopy/tests/test_attach_dataset.py
+++ b/syncopy/tests/test_attach_dataset.py
@@ -202,17 +202,30 @@ class TestAttachDataset:
         assert 'adt' not in locals()
 
         # repeat with hdf5 datasets
-        with tempfile.TemporaryDirectory() as tdir:
-            file1 = h5py.File(os.path.join(tdir, "dummy1.h5"), 'w')
+        #with tempfile.TemporaryDirectory() as tdir:
+        #    file1 = h5py.File(os.path.join(tdir, "dummy1.h5"), 'w')
+        #    extra_ds1 = file1.create_dataset("d1", extra_data1.shape)
+        #    extra_ds1[()] = extra_data1
+
+        #    file2 = h5py.File(os.path.join(tdir, "dummy2.h5"), 'w')
+        #    extra_ds2 = file2.create_dataset("d2", extra_data2.shape)
+        #    extra_ds2[()] = extra_data2
+
+        # repeat with hdf5 datasets
+        tfile1 = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
+        tfile1.close()
+        tfile2 = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
+        tfile2.close()
+        with h5py.File(tfile1.name, 'w') as file1:
             extra_ds1 = file1.create_dataset("d1", extra_data1.shape)
             extra_ds1[()] = extra_data1
 
-            file2 = h5py.File(os.path.join(tdir, "dummy2.h5"), 'w')
-            extra_ds2 = file2.create_dataset("d2", extra_data2.shape)
-            extra_ds2[()] = extra_data2
+            with h5py.File(tfile2.name, 'w') as file2:
+                extra_ds2 = file2.create_dataset("d2", extra_data2.shape)
+                extra_ds2[()] = extra_data2
 
-            some_local_func(extra_ds1, extra_ds2)
-            assert 'adt' not in locals()
+                some_local_func(extra_ds1, extra_ds2)
+                assert 'adt' not in locals()
 
     def test_attach_None_to_analog_data(self):
         """

--- a/syncopy/tests/test_discretedata.py
+++ b/syncopy/tests/test_discretedata.py
@@ -544,21 +544,24 @@ class TestWaveform():
         spiked = getSpikeData(nSpikes = numSpikes)
         spiked.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            tmp_spy_filename = os.path.join(tmpdirname, "mywffile.spike")
-            save(spiked, filename=tmp_spy_filename)
-            assert "waveform" in h5py.File(tmp_spy_filename, mode="r").keys()
-            spkd2 = load(filename=tmp_spy_filename)
-            assert isinstance(spkd2.waveform, h5py.Dataset), f"Expected h5py.Dataset, got {type(spkd2.waveform)}"
-            assert np.array_equal(spiked.waveform[()], spkd2.waveform[()])
+        tfile1 = tempfile.NamedTemporaryFile(suffix=".spike", delete=True)
+        tfile1.close()
+        tmp_spy_filename = tfile1.name
+        save(spiked, filename=tmp_spy_filename)
+        assert "waveform" in h5py.File(tmp_spy_filename, mode="r").keys()
+        spkd2 = load(filename=tmp_spy_filename)
+        assert isinstance(spkd2.waveform, h5py.Dataset), f"Expected h5py.Dataset, got {type(spkd2.waveform)}"
+        assert np.array_equal(spiked.waveform[()], spkd2.waveform[()])
 
-            # Test delete/unregister when setting to None.
-            spkd2.waveform = None
-            assert spkd2.waveform is None
-            assert "waveform" not in h5py.File(tmp_spy_filename, mode="r").keys()
+        # Test delete/unregister when setting to None.
+        spkd2.waveform = None
+        assert spkd2.waveform is None
+        assert "waveform" not in h5py.File(tmp_spy_filename, mode="r").keys()
 
-            # Test that we can set waveform again after deleting it.
-            spkd2.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
+        # Test that we can set waveform again after deleting it.
+        spkd2.waveform = np.ones((numSpikes, 3, waveform_dimsize), dtype=int)
+
+        tfile1.close()
 
     def test_psth_with_waveform(self):
         """Test that the waveform does not break frontend functions, like PSTH.


### PR DESCRIPTION
Changes Summary
----------------
- avoids calling with `with tempfile.TemporaryDirectory() as tdir`, which seems broken under Windows


Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
