### PR TITLE
Fix even more win tests

### DIFF
--- a/syncopy/tests/test_packagesetup.py
+++ b/syncopy/tests/test_packagesetup.py
@@ -64,46 +64,49 @@ def test_cleanup():
     else:
         assert False
 
-    with tempfile.TemporaryDirectory() as tmpDir:
+    tmpDir = tempfile.mkdtemp()
 
-        os.environ["SPYTMPDIR"] = tmpDir
-        commandStr = \
-            "import os; " +\
-            "import time; " +\
-            "import numpy as np; " +\
-            "import syncopy as spy; " +\
-            "dummy = spy.AnalogData(data=np.ones((10,10)), samplerate=1); " +\
-            "time.sleep(100)"
-        process = subprocess.Popen([sys.executable, "-c", commandStr])
-        time.sleep(8)
-        process.kill()
+    os.environ["SPYTMPDIR"] = tmpDir
+    commandStr = \
+        "import os; " +\
+        "import time; " +\
+        "import numpy as np; " +\
+        "import syncopy as spy; " +\
+        "dummy = spy.AnalogData(data=np.ones((10,10)), samplerate=1); " +\
+        "time.sleep(100)"
+    process = subprocess.Popen([sys.executable, "-c", commandStr])
+    time.sleep(12)
+    process.kill()
 
-        # get inventory of external Syncopy instance's temp storage
-        spyGarbage = glob(os.path.join(tmpDir, "*"))
+    # get inventory of external Syncopy instance's temp storage
+    num_garbage_before = len(glob(os.path.join(tmpDir, "*.analog")))
+    assert num_garbage_before > 0
 
-        assert len(spyGarbage)
+    # launch 2nd external instance with same $SPYTMPDIR, create 2nd `AnalogData`
+    # object, run `cleanup` and keep instance alive in background (for max. 100s)
+    commandStr = \
+        "import time; " +\
+        "import syncopy as spy; " +\
+        "import numpy as np; " +\
+        "dummy = spy.AnalogData(data=np.ones((10,10)), samplerate=1); " +\
+        "time.sleep(5)" +\
+        "spy.cleanup(older_than=0, interactive=False, only_current_session=True); " +\
+        "time.sleep(100)"
+    process2 = subprocess.Popen([sys.executable, "-c", commandStr],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                text=True)
+    time.sleep(12)
 
-        # launch 2nd external instance with same $SPYTMPDIR, create 2nd `AnalogData`
-        # object, run `cleanup` and keep instance alive in background (for max. 100s)
-        commandStr = \
-            "import time; " +\
-            "import syncopy as spy; " +\
-            "import numpy as np; " +\
-            "dummy = spy.AnalogData(data=np.ones((10,10)), samplerate=1); " +\
-            "spy.cleanup(older_than=0, interactive=False, only_current_session=True); " +\
-            "time.sleep(100)"
-        process2 = subprocess.Popen([sys.executable, "-c", commandStr],
-                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                    text=True)
-        time.sleep(8)
+    num_garbage_after = len(glob(os.path.join(tmpDir, "*.analog")))
 
-        # ensure `cleanup` call removed first instance's garbage but 2nd `AnalogData`
-        # belonging to 2nd instance launched above is unharmed            
-        assert len(glob(os.path.join(tmpDir, "*.analog"))) == 1
+    # ensure `cleanup` call removed first instance's garbage but 2nd `AnalogData`
+    # belonging to 2nd instance launched above is unharmed
+    assert num_garbage_after == num_garbage_before
 
-        # now kill 2nd instance and wipe `tmpDir`
-        process2.kill()
-        time.sleep(1)
+    # now kill 2nd instance and wipe `tmpDir`
+    process2.kill()
+    time.sleep(1)
 
     del os.environ["SPYTMPDIR"]
     time.sleep(1)
+    shutil.rmtree(tmpDir)

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -394,14 +394,15 @@ class TestSpikeSelections:
                      'channel': [6, 2],
                      'unit': [0, 3],
                      'latency': [-1, 4]}
-        res = self.spike_data.selectdata(selection)
+        spkd = getSpikeData()
+        res = spkd.selectdata(selection)
 
         # hand pick selection from the arrays
-        dat_arr = self.spike_data.data
+        dat_arr = spkd.data
 
         # these are trial intervals in sample indices!
-        trial2 = self.spike_data.trialdefinition[2, :2]
-        trial4 = self.spike_data.trialdefinition[4, :2]
+        trial2 = spkd.trialdefinition[2, :2]
+        trial4 = spkd.trialdefinition[4, :2]
 
         # create boolean mask for trials [2, 4]
         bm = (dat_arr[:, 0] >= trial2[0]) & (dat_arr[:, 0] <= trial2[1])
@@ -415,10 +416,12 @@ class TestSpikeSelections:
 
         # latency [-1, 4]
         # to index all trials at once
-        time_vec = np.concatenate([t for t in self.spike_data.time])
+        time_vec = np.concatenate([t for t in spkd.time])
         bm = bm & ((time_vec >= -1) & (time_vec <= 4))
 
         # finally compare to selection result
+        print(f"bm={bm}")
+        print(f"dat_arr[bm].shape={dat_arr[bm].shape}, res.data shape={res.data[()].shape}")
         assert np.all(dat_arr[bm] == res.data[()])
 
     def test_spike_valid(self):

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -420,8 +420,9 @@ class TestSpikeSelections:
         bm = bm & ((time_vec >= -1) & (time_vec <= 4))
 
         # finally compare to selection result
-        print(f"bm={bm}")
-        print(f"dat_arr[bm].shape={dat_arr[bm].shape}, res.data shape={res.data[()].shape}")
+        print(f"tag12345 bm.shape={bm.shape} : {bm}")
+        print(f"res.data shape={res.data[()].shape}")
+        print(f"dat_arr[bm].shape={dat_arr[bm].shape}")
         assert np.all(dat_arr[bm] == res.data[()])
 
     def test_spike_valid(self):


### PR DESCRIPTION
Changes Summary
----------------
- fixes `test_packagesetup.py.test_cleanup()` under Windows by avoiding `with Tempdir`-move
- adds debug output to `test_selectdata.TestSpikeSelections:test_spike_selection` in the hope of finding out what is going on  the ESI runner. The test is actually green locally under Windows on my laptop!


Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
