### PR TITLE
478 creating a dummy dataset using snpanalogdata does not create a data set with desired name of the channels

### DIFF
--- a/syncopy/datatype/continuous_data.py
+++ b/syncopy/datatype/continuous_data.py
@@ -354,8 +354,12 @@ class ContinuousData(BaseData, ABC):
         # Call initializer
         super().__init__(data=data, **kwargs)
 
-        # might be set from concatenation
-        if self.channel is None:
+        # catches channel propagation
+        # from concatenation of syncopy data objects
+        if self._channel is None:
+            self.channel = channel
+        # overwrites channels from concatenation if desired
+        elif channel is not None:
             self.channel = channel
 
         if self.data is not None:

--- a/syncopy/tests/test_continuousdata.py
+++ b/syncopy/tests/test_continuousdata.py
@@ -196,12 +196,14 @@ class TestAnalogData():
 
         # -- test with single array--
 
-        dummy = AnalogData(data=self.data)
+        chan_labels = [str(i) for i in range(self.nc)]
+        dummy = AnalogData(data=self.data, channel=chan_labels)
         assert dummy.dimord == AnalogData._defaultDimord
         assert dummy.channel.size == self.nc
         assert (dummy.sampleinfo == [0, self.ns]).min()
         assert dummy.trialinfo.shape == (1, 0)
         assert np.array_equal(dummy.data, self.data)
+        assert np.all(dummy.channel == chan_labels)
 
         # wrong shape for data-type
         with pytest.raises(SPYValueError):


### PR DESCRIPTION
Changes Summary
----------------
- closes #478 


Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
