### PR TITLE
CHG: Handle NaNs in preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog of SyNCoPy
 All notable changes to this project will be documented in this file.
 
+## [unpublished]
+
+### Changed
+- FIR filters work around NaNs in the input via slower direct convolutions
+
 ## [2023.03]
 
 ### NEW

--- a/syncopy/preproc/firws.py
+++ b/syncopy/preproc/firws.py
@@ -7,10 +7,10 @@
 # Builtin/3rd party package imports
 import numpy as np
 import scipy.signal.windows as sci_win
-from scipy.signal import fftconvolve
+from scipy.signal import convolve
 
 
-def apply_fir(data, fkernel):
+def apply_fir(data, fkernel, method='fft'):
 
     """
     Convolution of the input `data` with a FIR filter.
@@ -24,6 +24,9 @@ def apply_fir(data, fkernel):
         columns represent individual channels.
     fkernel : (N,) :class:`numpy.ndarray`
         The time domain representation of the FIR filter
+    method : ('direct', 'fft')
+        Direct convolution in the time-domain or fft based
+        convolution
 
     Returns
     -------
@@ -36,7 +39,7 @@ def apply_fir(data, fkernel):
     slices[0] = slice(None)
     slices = tuple(slices)
 
-    filtered = fftconvolve(data, fkernel[slices], mode="same")
+    filtered = convolve(data, fkernel[slices], mode="same", method=method)
     return filtered
 
 

--- a/syncopy/preproc/preprocessing.py
+++ b/syncopy/preproc/preprocessing.py
@@ -10,7 +10,8 @@ import numpy as np
 from syncopy import AnalogData
 from syncopy.shared.parsers import data_parser, scalar_parser, array_parser
 from syncopy.shared.tools import get_defaults, get_frontend_cfg
-from syncopy.shared.errors import SPYValueError, SPYInfo
+from syncopy.shared.errors import SPYValueError, SPYInfo, SPYWarning
+from syncopy.shared.metadata import metadata_from_hdf5_file
 from syncopy.shared.kwarg_decorators import (
     unwrap_cfg,
     unwrap_select,
@@ -348,6 +349,7 @@ def preprocessing(
     # only zscoring
     else:
         filterMethod = None
+
     # -------------------------------------------
     # Call the chosen filter ComputationalRoutine
     # -------------------------------------------
@@ -367,6 +369,21 @@ def preprocessing(
         filterMethod.compute(
             data, filtered, parallel=kwargs.get("parallel"), log_dict=log_dict
         )
+
+        # give warnings if NaNs were present
+        nan_trials = []
+        for key, value in metadata_from_hdf5_file(filtered.filename).items():
+            if 'has_nan' in key and value:
+                # try to also record the trial numbers
+                trl_num = key.split('__')[-1].split('_')[0]
+                nan_trials.append(int(trl_num))
+
+        if len(nan_trials) != 0:
+            msg = "Data contains NaNs! See `.info['nan_trials']` for the offending trials"
+            if filter_class == 'but':
+                msg += "\n\t\t try using a 'onepass' FIR filter of low order.."
+            SPYWarning(msg)
+        filtered.info['nan_trials'] = nan_trials
 
     # -- check for post-processing flags --
 

--- a/syncopy/tests/test_preproc.py
+++ b/syncopy/tests/test_preproc.py
@@ -243,6 +243,29 @@ class TestButterworth:
             call(hilbert='absnot')
         assert "one of {'" in str(err)
 
+    def test_but_NaN(self):
+
+        nSamples = 20
+        nTrials = 5
+        nChannels = 3
+
+        # create test data with NaNs in 2 trials
+        arr = [(i + 1) * np.ones((nSamples, nChannels)) for i in range(nTrials)]
+        # add NaNs in 2nd and last trial
+        arr[1][5, 1] = np.nan
+        arr[-1][10:15, 2] = np.nan
+        adata = AnalogData(data=arr, samplerate=50)
+        res = ppfunc(adata,
+                     freq=20,
+                     filter_class='but')
+
+        # IIR filters can't work around NaNs
+        assert np.sum(np.isnan(res.trials[0])) == 0
+        assert np.sum(np.isnan(res.trials[1])) == nSamples
+        assert np.sum(np.isnan(res.trials[4])) == nSamples
+        # check that metadata got propagated
+        assert res.info['nan_trials'] == [1, 4]
+
 
 class TestFIRWS:
 
@@ -449,6 +472,41 @@ class TestFIRWS:
             call(hilbert='absnot')
         assert "one of {'" in str(err)
 
+    def test_firws_NaN(self):
+
+        nSamples = 20
+        nTrials = 5
+        nChannels = 3
+        order = 6  # length of the fir filter
+
+        # create test data with NaNs in 2 trials
+        arr = [(i + 1) * np.ones((nSamples, nChannels)) for i in range(nTrials)]
+        # add NaNs in 2nd and last trial
+        arr[1][5, 1] = np.nan
+        arr[-1][10:15, 2] = np.nan  # "NaN island"
+        adata = AnalogData(data=arr, samplerate=50)
+        res = ppfunc(adata,
+                     freq=20,
+                     filter_class='firws',
+                     order=order,
+                     direction='onepass')
+
+        # no NaNs in 1st trial
+        assert np.sum(np.isnan(res.trials[0])) == 0
+        # we "want" only NaNs in the result, where the filter
+        # support covers/touches the NaN sample(s) in the input
+        # for an isolated NaN this happens exactly for order (filter length) samples
+        assert np.sum(np.isnan(res.trials[1])) == 1 + order
+        # for an island of NaNs, the NaN region
+        # grows in total also by the filter order
+        number_NaN = np.sum(np.isnan(adata.trials[4]))
+        assert np.sum(np.isnan(res.trials[4])) == number_NaN + order
+        # final sanity check
+        assert np.sum(np.isnan(res.trials[4])) < nSamples
+
+        # finally check that the metadata got propagated
+        assert res.info['nan_trials'] == [1, 4]
+
 
 class TestDetrending:
 
@@ -505,6 +563,43 @@ class TestDetrending:
             test_method = getattr(self, test_name)
             test_method()
         client.close()
+
+    def test_detr_NaN(self):
+
+        nSamples = 20
+        nTrials = 5
+        nChannels = 3
+
+        # create test data with NaNs in 2 trials
+        arr = [(i + 1) * np.ones((nSamples, nChannels)) for i in range(nTrials)]
+        # add NaNs in 2nd and last trial
+        arr[1][5, 1] = np.nan
+        arr[-1][10:15, 2] = np.nan
+        adata = AnalogData(data=arr, samplerate=50)
+
+        # -- demeaning --
+        res = ppfunc(adata,
+                     filter_class=None,
+                     polyremoval=0)
+
+        # detrending can't work around NaNs
+        assert np.sum(np.isnan(res.trials[0])) == 0
+        assert np.sum(np.isnan(res.trials[1])) == nSamples
+        assert np.sum(np.isnan(res.trials[4])) == nSamples
+        # check that metadata got propagated
+        assert res.info['nan_trials'] == [1, 4]
+
+        # -- linear detrending --
+        res = ppfunc(adata,
+                     filter_class=None,
+                     polyremoval=1)
+
+        # detrending can't work around NaNs
+        assert np.sum(np.isnan(res.trials[0])) == 0
+        assert np.sum(np.isnan(res.trials[1])) == nSamples
+        assert np.sum(np.isnan(res.trials[4])) == nSamples
+        # check that metadata got propagated
+        assert res.info['nan_trials'] == [1, 4]
 
 
 class TestStandardize:


### PR DESCRIPTION
Changes Summary
----------------
- FIR filtering switches to slower time-domain convolutions if NaNs are present, still giving results if at least `order` (filter length) away from any NaN samples
- for IIR filtering, we can't do anything but the user gets a warning and the offending (NaN containing) trials can be accessed via `.info['nan_trials']`
- we probably could roll out this NaN reporting also elsewhere (specest, connectivity, ...)
- closes #480


Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
