### PR TITLE
Fix GitHub dependabot alert

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2214,4 +2214,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "82d743dbb5a1b572193d1733f79612ea7840bb1ff8c6c7457418991a8d9071cb"
+content-hash = "0538410f5d92f8949da09caa475eacc9c66e34bbb48e5105078f9bdca10bc93f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ fooof = ">=1.0"
 [tool.poetry.group.dev.dependencies]
 black = "^22.6.0"
 pytest = "^7.0"
-ipython = "^8.0"
+ipython = ">=8.10"
 pytest-cov = "^3.0.0"
 sphinx-book-theme = ">=1.0.1"
 sphinx-automodapi = "^0.14.1"


### PR DESCRIPTION
Changes Summary
----------------
- Update ipython to `>= 8.10` (from `^8.0`) to remove the following message, that I get on the console every time I push or pull (and others will get it too, of course):
```
remote: GitHub found 1 vulnerability on esi-neuroscience/syncopy's default branch (1 moderate). To find out more, visit:
remote:      https://github.com/esi-neuroscience/syncopy/security/dependabot/6
```



Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
