### PR TITLE
489 redesign time property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - created dedicated `syncopy.synthdata` module
 - synthetic data routines use generators instead of lists
 - FIR filters work around NaNs in the input via slower direct convolutions
+- `.time` property returns either an iterable or a single time array when indexed
 
 ## [2023.03]
 

--- a/syncopy/datatype/base_data.py
+++ b/syncopy/datatype/base_data.py
@@ -1034,11 +1034,11 @@ class BaseData(ABC):
 
     @property
     def trials(self):
-        """list-like array of trials"""
+        """list-like iterable of trials"""
 
         if self.sampleinfo is not None:
             trial_ids = list(range(self.sampleinfo.shape[0]))
-            # this is cheap as it just initializes a list-like object
+            # this is cheap as it just initializes an indexable generator
             # with no real data and/or computation!
             return TrialIndexer(self, trial_ids)
         else:

--- a/syncopy/datatype/continuous_data.py
+++ b/syncopy/datatype/continuous_data.py
@@ -86,7 +86,7 @@ class ContinuousData(BaseData, ABC):
         for attr in ppattrs:
             value = getattr(self, attr)
             if hasattr(value, 'shape') and attr == "data" and self.sampleinfo is not None:
-                tlen = np.unique([sinfo[1] - sinfo[0] for sinfo in self.sampleinfo])
+                tlen = np.unique(np.diff(self.sampleinfo))
                 if tlen.size == 1:
                     trlstr = "of length {} ".format(str(tlen[0]))
                 else:

--- a/syncopy/datatype/continuous_data.py
+++ b/syncopy/datatype/continuous_data.py
@@ -16,6 +16,7 @@ from collections.abc import Iterator
 
 # Local imports
 from .base_data import BaseData, FauxTrial, _definetrial
+from .util import TimeIndexer
 from .methods.definetrial import definetrial
 from syncopy.shared.parsers import scalar_parser, array_parser
 from syncopy.shared.errors import SPYValueError, SPYWarning
@@ -179,10 +180,12 @@ class ContinuousData(BaseData, ABC):
 
     @property
     def time(self):
-        """list(float): trigger-relative time axes of each trial """
+        """indexable iterable of the time arrays"""
         if self.samplerate is not None and self.sampleinfo is not None:
-            return [(np.arange(0, stop - start) + self._t0[tk]) / self.samplerate \
-                    for tk, (start, stop) in enumerate(self.sampleinfo)]
+            trial_ids = list(range(self.sampleinfo.shape[0]))
+            # this is cheap as it just initializes a list-like generator
+            # with no real data and/or computation!
+            return TimeIndexer(self, trial_ids)
 
     # Helper function that grabs a single trial
     def _get_trial(self, trialno):

--- a/syncopy/datatype/discrete_data.py
+++ b/syncopy/datatype/discrete_data.py
@@ -144,7 +144,7 @@ class DiscreteData(BaseData, ABC):
     def time(self):
         """list(float): trigger-relative time of each event """
         if self.samplerate is not None and self.sampleinfo is not None:
-            return [(trl[:,self.dimord.index("sample")] - self.sampleinfo[tk,0] + self._t0[tk]) / self.samplerate \
+            return [(trl[:,self.dimord.index("sample")] - self.sampleinfo[tk,0] + self.trialdefinition[tk, 2]) / self.samplerate \
                     for tk, trl in enumerate(self.trials)]
 
     @property
@@ -177,7 +177,7 @@ class DiscreteData(BaseData, ABC):
     def trialtime(self):
         """list(:class:`numpy.ndarray`): trigger-relative sample times in s"""
         if self.samplerate is not None and self.sampleinfo is not None:
-            sample0 = self.sampleinfo[:, 0] - self._t0[:]
+            sample0 = self.sampleinfo[:, 0] - self._t0
             sample0 = np.append(sample0, np.nan)[self.trialid]
             return (self.data[:, self.dimord.index("sample")] - sample0) / self.samplerate
 

--- a/syncopy/datatype/selector.py
+++ b/syncopy/datatype/selector.py
@@ -478,14 +478,14 @@ class Selector:
                     if step is None:
                         step = 1
                     nSamples = (stop - start) / step
-                    endSample = stop + data._t0[trlno]
+                    endSample = stop + data._trialdefinition[trlno, 2]
                     t0 = int(endSample - nSamples)
                 else:
                     nSamples = len(tsel)
                     if nSamples == 0:
                         t0 = 0
                     else:
-                        t0 = data._t0[trlno]
+                        t0 = data._trialdefinition[trlno, 2]
                 trlDef[tk, :3] = [counter, counter + nSamples, t0]
                 trlDef[tk, 3:] = trl[trlno, 3:]
                 counter += nSamples

--- a/syncopy/datatype/util.py
+++ b/syncopy/datatype/util.py
@@ -82,7 +82,7 @@ class TimeIndexer:
 
     def construct_time_array(self, trialno):
 
-        start, stop, offset = self.data_object.trialdefinition[trialno, :]
+        start, stop, offset = self.data_object.trialdefinition[trialno, :3]
         return (np.arange(0, stop - start) + offset) / self.data_object.samplerate
 
     def __getitem__(self, trialno):

--- a/syncopy/datatype/util.py
+++ b/syncopy/datatype/util.py
@@ -4,6 +4,7 @@ Helpers and tools for Syncopy data classes
 
 import os
 from numbers import Number
+import numpy as np
 
 # Syncopy imports
 from syncopy import __storage__, __storagelimit__, __sessionid__
@@ -45,6 +46,57 @@ class TrialIndexer:
     def __iter__(self):
         # this generator gets freshly created and exhausted
         # for each new iteration, with only 1 trial being in memory
+        # at any given time
+        yield from (self[i] for i in self.idx_list)
+
+    def __len__(self):
+        return self._len
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return "{} element iterable".format(self._len)
+
+
+class TimeIndexer:
+
+    def __init__(self, data_object, idx_list):
+        """
+        Class to obtain an indexable time array iterable from
+        an instantiated Syncopy data class `data_object`.
+        Relies on the `trialdefinition` of the respective
+        `data_object`.
+
+        Parameters
+        ----------
+        data_object : Syncopy data class, e.g. AnalogData
+
+        idx_list : list
+            List of valid trial indices
+        """
+
+        self.data_object = data_object
+        self.idx_list = idx_list
+        self._len = len(idx_list)
+
+    def construct_time_array(self, trialno):
+
+        start, stop, offset = self.data_object.trialdefinition[trialno, :]
+        return (np.arange(0, stop - start) + offset) / self.data_object.samplerate
+
+    def __getitem__(self, trialno):
+        # single trial access via index operator []
+        if not isinstance(trialno, Number):
+            raise SPYTypeError(trialno, "trial index", "single number to index a single trial")
+        if trialno not in self.idx_list:
+            lgl = "index of existing trials"
+            raise SPYValueError(lgl, "trial index", trialno)
+        return self.construct_time_array(trialno)
+
+    def __iter__(self):
+        # this generator gets freshly created and exhausted
+        # for each new iteration, with only 1 time array being in memory
         # at any given time
         yield from (self[i] for i in self.idx_list)
 
@@ -106,6 +158,3 @@ def setup_storage(storage_dir=__storage__):
             raise IOError(err.format(storage_dir, str(exc)))
 
     return get_dir_size(storage_dir, out="GB")
-
-
-


### PR DESCRIPTION
Changes Summary
----------------
- new `TimeIndexer`, works very similiar to the `TrialIndexer`
- no more costly creating the full list of all trial-time arrays for a simple `.time[tk]`
- tests required NO changes, meaning that `.time` returned a list before this change was not even required and/or tested
- minor additional performance improvements for the `__str__` method

Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
