### PR TITLE
CHG: Improve signature and doc of synthdata routines

### DIFF
--- a/doc/source/scripts/synth_data1.py
+++ b/doc/source/scripts/synth_data1.py
@@ -5,7 +5,7 @@ import syncopy as spy
 def generate_noisy_harmonics(nSamples, nChannels, samplerate):
 
     f1, f2 = 20, 50 # the harmonic frequencies in Hz
-    
+
     # the sampling times vector
     tvec = np.arange(nSamples) * 1 / samplerate
 

--- a/doc/source/user/synth_data.rst
+++ b/doc/source/user/synth_data.rst
@@ -1,4 +1,4 @@
-.. _synth_data:
+.. _synthdata:
    
 Synthetic Data
 ==============
@@ -9,6 +9,22 @@ For testing and demonstrational purposes it is always good to work with syntheti
    :local:
 
 .. _gen_synth_recipe:
+
+
+Built-in Generators
+-------------------
+
+These generators return either a multi-trial :class:`~syncopy.AnalogData` object or a single-trial NumPy array, so to import them into Syncopy use the :ref:`gen_synth_recipe` described above.
+
+.. autosummary::
+
+   .. currentmodule:: 
+   syncopy.synthdata.harmonic
+   syncopy.synthdata.linear_trend
+   syncopy.synthdata.phase_diffusion
+   syncopy.synthdata.AR2_network
+   syncopy.synthdata.white_noise
+
 
 General Recipe
 --------------
@@ -76,19 +92,6 @@ Now we can directly run a multi-tapered FFT analysis and plot the power spectra 
 
 As constructed, we have two harmonic peaks at the respective frequencies (20Hz and 50Hz) and the white noise floor on all channels.
     
-Built-in Generators
--------------------
-
-These generators return single-trial NumPy arrays, so to import them into Syncopy use the :ref:`gen_synth_recipe` described above.
-
-.. autosummary::
-
-   .. currentmodule:: 
-   syncopy.tests.synth_data.harmonic
-   syncopy.tests.synth_data.linear_trend
-   syncopy.tests.synth_data.phase_diffusion
-   syncopy.tests.synth_data.AR2_network
-   syncopy.tests.synth_data.white_noise
 
 
 

--- a/syncopy/synthdata/analog.py
+++ b/syncopy/synthdata/analog.py
@@ -16,14 +16,27 @@ _2pi = np.pi * 2
 
 
 @collect_trials
-def white_noise(nSamples=1000, nChannels=2, seed=42):
+def white_noise(nSamples=1000, nChannels=2, seed=None):
     """
     Plain white noise with unity standard deviation.
 
-    Pass an extra `nTrials` `int` Parameter to generate multi-trial data using the `@collect_trials` decorator.
+    Parameters
+    ----------
+    nSamples : int
+        Number of samples per trial
+    nChannels : int
+        Number of channels
+    seed : int or None
+        Set to a number to get reproducible random numbers
+
+    Returns
+    --------
+    wn : :class:`syncopy.AnalogData` or numpy.ndarray
     """
+
     rng = np.random.default_rng(seed)
-    return rng.normal(size=(nSamples, nChannels))
+    wn = rng.normal(size=(nSamples, nChannels))
+    return wn
 
 
 @collect_trials
@@ -31,7 +44,19 @@ def linear_trend(y_max, nSamples=1000, nChannels=2):
     """
     A linear trend  on all channels from 0 to `y_max` in `nSamples`.
 
-    Pass an extra `nTrials` `int` Parameter to generate multi-trial data using the `@collect_trials` decorator.
+    Parameters
+    ----------
+    y_max : float
+        Ordinate value at the last sample,
+        slope is then given by samplerate * y_max / nSamples
+    nSamples : int
+        Number of samples per trial
+    nChannels : int
+        Number of channels
+
+    Returns
+    --------
+    trend : :class:`syncopy.AnalogData` or numpy.ndarray
     """
     trend = np.linspace(0, y_max, nSamples)
     return np.column_stack([trend for _ in range(nChannels)])
@@ -42,7 +67,21 @@ def harmonic(freq, samplerate, nSamples=1000, nChannels=2):
     """
     A harmonic with frequency `freq`.
 
-    Pass an extra `nTrials` `int` Parameter to generate multi-trial data using the `@collect_trials` decorator.
+    Parameters
+    ----------
+    freq : float
+        Frequency of the harmonic in Hz
+    samplerate : float
+        Sampling rate in Hz
+    nSamples : int
+        Number of samples per trial
+    nChannels : int
+        Number of channels
+
+    Returns
+    --------
+    harm : :class:`syncopy.AnalogData` or numpy.ndarray
+
     """
     # the sampling times vector needed for construction
     tvec = np.arange(nSamples) * 1 / samplerate
@@ -90,19 +129,18 @@ def phase_diffusion(freq,
         If set to ``True`` initial phases are randomized
     return_phase : bool, optional
         If set to true returns the phases in radians
-    seed: None or int, passed on to `np.random.default_rng`.
+    seed: None or int
           Set to an `int` to get reproducible results, or `None` for random ones.
-    nTrials: int, number of trials to generate using the `@collect_trials` decorator.
 
     Returns
     -------
-    phases : numpy.ndarray
+    phases : :class:`syncopy.AnalogData` or numpy.ndarray
         Synthetic `nSamples` x `nChannels` data array simulating noisy phase
         evolution/diffusion
     """
 
     # white noise
-    wn = white_noise(nSamples=nSamples, nChannels=nChannels, seed=seed)
+    wn = white_noise(nSamples=nSamples, nChannels=nChannels, seed=seed, nTrials=None)
 
     tvec = np.linspace(0, nSamples / samplerate, nSamples)
     omega0 = 2 * np.pi * freq
@@ -162,7 +200,6 @@ def AR2_network(AdjMat=None, nSamples=1000, alphas=(0.55, -0.8), seed=None):
         When using this function with an `nTrials` argument (`@collect_trials` wrapper), and you *do*
         want the data of all trials to be identical (and reproducible),
         pass a single scalar seed and set 'seed_per_trial=False'.
-    nTrials: int, number of trials to generate using the `@collect_trials` decorator.
 
     Returns
     -------

--- a/syncopy/tests/backend/test_conn.py
+++ b/syncopy/tests/backend/test_conn.py
@@ -191,7 +191,7 @@ def test_wilson():
     CSDav = np.zeros((nSamples // 2 + 1, nChannels, nChannels), dtype=np.complex64)
     for _ in range(nTrials):
 
-        sol = synthdata.AR2_network(nSamples=nSamples, seed=None)
+        sol = synthdata.AR2_network(nSamples=nSamples, seed=None, nTrials=None)
         # --- get the (single trial) CSD ---
 
         CSD, freqs = csd.csd(sol, fs,
@@ -276,7 +276,7 @@ def test_granger():
     for _ in range(nTrials):
 
         # -- simulate 2 AR(2) processes with 2->1 coupling --
-        sol = synthdata.AR2_network(nSamples=nSamples)
+        sol = synthdata.AR2_network(nSamples=nSamples, nTrials=None)
 
         # --- get CSD ---
         bw = 2

--- a/syncopy/tests/test_cfg.py
+++ b/syncopy/tests/test_cfg.py
@@ -35,7 +35,7 @@ class TestCfg:
 
     # -- use flat white noise as test data --
 
-    adata = synthdata.white_noise(nTrials,
+    adata = synthdata.white_noise(nTrials=nTrials,
                                   nSamples=nSamples,
                                   nChannels=nChannels,
                                   samplerate=fs)

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -107,10 +107,10 @@ class TestGranger:
     cpl_idx = np.where(AdjMat)
     nocpl_idx = np.where(AdjMat == 0)
 
-    data = synthdata.AR2_network(nTrials,
-                                 AdjMat=AdjMat,
+    data = synthdata.AR2_network(AdjMat=AdjMat,
                                  nSamples=nSamples,
                                  samplerate=fs,
+                                 nTrials=nTrials,
                                  seed=42)
 
     time_span = [-1, nSamples / fs - 1]   # -1s offset
@@ -279,20 +279,20 @@ class TestCoherence:
 
     f1, f2 = 20, 40
     # a lot of phase diffusion (1% per step) in the 20Hz band
-    s1 = synthdata.phase_diffusion(nTrials, freq=f1,
+    s1 = synthdata.phase_diffusion(nTrials=nTrials, freq=f1,
                                    eps=.03,
                                    nChannels=nChannels,
                                    nSamples=nSamples,
                                    seed=helpers.test_seed)
 
     # little diffusion in the 40Hz band
-    s2 = synthdata.phase_diffusion(nTrials, freq=f2,
+    s2 = synthdata.phase_diffusion(nTrials=nTrials, freq=f2,
                                    eps=.001,
                                    nChannels=nChannels,
                                    nSamples=nSamples,
                                    seed=helpers.test_seed)
 
-    wn = synthdata.white_noise(nTrials, nChannels=nChannels, nSamples=nSamples,
+    wn = synthdata.white_noise(nTrials=nTrials, nChannels=nChannels, nSamples=nSamples,
                                seed=helpers.test_seed)
 
     # superposition
@@ -523,20 +523,20 @@ class TestCSD:
 
     f1, f2 = 20, 40
     # a lot of phase diffusion (1% per step) in the 20Hz band
-    s1 = synthdata.phase_diffusion(nTrials, freq=f1,
+    s1 = synthdata.phase_diffusion(nTrials=nTrials, freq=f1,
                                    eps=.01,
                                    nChannels=nChannels,
                                    nSamples=nSamples,
                                    seed=42)
 
     # little diffusion in the 40Hz band
-    s2 = synthdata.phase_diffusion(nTrials, freq=f2,
+    s2 = synthdata.phase_diffusion(nTrials=nTrials, freq=f2,
                                    eps=.001,
                                    nChannels=nChannels,
                                    nSamples=nSamples,
                                    seed=42)
 
-    wn = synthdata.white_noise(nTrials, nChannels=nChannels, nSamples=nSamples)
+    wn = synthdata.white_noise(nTrials=nTrials, nChannels=nChannels, nSamples=nSamples)
 
     # superposition
     data = s1 + s2 + wn
@@ -596,14 +596,16 @@ class TestCorrelation:
                                        nChannels=nChannels,
                                        nSamples=nSamples,
                                        seed=42,
-                                       return_phase=True)
+                                       return_phase=True,
+                                       nTrials=None)
         # same frequency but more diffusion
         p2 = synthdata.phase_diffusion(freq=f1,
                                        eps=0.1,
                                        nChannels=1,
                                        nSamples=nSamples,
                                        seed=42,
-                                       return_phase=True)
+                                       return_phase=True,
+                                       nTrials=None)
 
         # set 2nd channel to higher phase diffusion
         p1[:, 1] = p2[:, 0]
@@ -741,12 +743,12 @@ class TestPPC:
 
     f1 = 20
     # phase diffusion (1% per step) in the 20Hz band
-    s1 = synthdata.phase_diffusion(nTrials, freq=f1,
+    s1 = synthdata.phase_diffusion(nTrials=nTrials, freq=f1,
                                    eps=.01,
                                    nChannels=nChannels,
                                    nSamples=nSamples,
                                    seed=helpers.test_seed)
-    wn = synthdata.white_noise(nTrials, nChannels=nChannels, nSamples=nSamples,
+    wn = synthdata.white_noise(nTrials=nTrials, nChannels=nChannels, nSamples=nSamples,
                                seed=helpers.test_seed)
 
     # superposition

--- a/syncopy/tests/test_preproc.py
+++ b/syncopy/tests/test_preproc.py
@@ -514,8 +514,8 @@ class TestDetrending:
 
     nTrials = 2
     nSamples = 5000
-    AData = sd.linear_trend(nTrials, nSamples=nSamples, y_max=10)
-    AData += sd.white_noise(nTrials, nSamples=nSamples) + 5  # add constant
+    AData = sd.linear_trend(nTrials=2, nSamples=nSamples, y_max=10)
+    AData += sd.white_noise(nTrials=2, nSamples=nSamples) + 5  # add constant
 
     def test_demeaning(self):
 
@@ -608,7 +608,7 @@ class TestStandardize:
 
     nTrials = 2
     nSamples = 5000
-    AData = 100 * sd.white_noise(nTrials, nSamples=nSamples) + 5  # add constant
+    AData = 100 * sd.white_noise(nTrials=nTrials, nSamples=nSamples) + 5  # add constant
 
     def test_standardize(self):
 

--- a/syncopy/tests/test_resampledata.py
+++ b/syncopy/tests/test_resampledata.py
@@ -30,7 +30,7 @@ class TestDownsampling:
     fNy = fs / 2
 
     # -- use flat white noise as test data --
-    adata = synthdata.white_noise(nTrials,
+    adata = synthdata.white_noise(nTrials=nTrials,
                                   nChannels=nChannels,
                                   nSamples=nSamples,
                                   samplerate=fs,
@@ -170,7 +170,7 @@ class TestResampling:
     fNy = fs / 2
 
     # -- use flat white noise as test data --
-    adata = synthdata.white_noise(nTrials,
+    adata = synthdata.white_noise(nTrials=nTrials,
                                   nChannels=nChannels,
                                   nSamples=nSamples,
                                   samplerate=fs,

--- a/syncopy/tests/test_statistics.py
+++ b/syncopy/tests/test_statistics.py
@@ -227,14 +227,14 @@ class TestSumStatistics:
 
     def test_itc(self, do_plot=True):
 
-        adata = sd.white_noise(100,
+        adata = sd.white_noise(nTrials=100,
                                nSamples=1000,
                                nChannels=2,
                                samplerate=500,
                                seed=42)
 
         # add simple 60Hz armonic
-        adata += sd.harmonic(100,
+        adata += sd.harmonic(nTrials=100,
                              freq=60,
                              nSamples=1000,
                              nChannels=2,
@@ -365,7 +365,7 @@ class TestJackknife:
         """
         nTrials = 10
         nSamples = 500
-        adata = 10 * sd.white_noise(nTrials, nSamples=nSamples, seed=helpers.test_seed)
+        adata = 10 * sd.white_noise(nTrials=nTrials, nSamples=nSamples, seed=helpers.test_seed)
         # to test for property propagation
         adata.channel = [f'chV_{i}' for i in range(1, 3)]
 
@@ -414,7 +414,7 @@ class TestJackknife:
         nSamples = 1000
         # sufficient to check this entry
         show_kwargs = {'channel_i': 0, 'channel_j': 1}
-        adata = sd.white_noise(nTrials, nSamples=nSamples, seed=helpers.test_seed)
+        adata = sd.white_noise(nTrials=nTrials, nSamples=nSamples, seed=helpers.test_seed)
 
         # confidence for 100 trials from
         # above mentioned publication for squared coherence
@@ -541,7 +541,7 @@ class TestJackknife:
         # weak coupling 1 -> 0
         AdjMat[1, 0] = 0.025
         nTrials = 35
-        adata = sd.AR2_network(nTrials, AdjMat=AdjMat, seed=42)
+        adata = sd.AR2_network(nTrials=nTrials, AdjMat=AdjMat, seed=42)
         # true causality is at 200Hz
         flims = [190, 210]
 

--- a/syncopy/tests/test_synthdata.py
+++ b/syncopy/tests/test_synthdata.py
@@ -39,9 +39,9 @@ def test_trial_collection():
     assert len(adata.time[0]) == cfg.nSamples
     assert adata.samplerate == cfg.samplerate
 
-    # without nTrials, the decorator gets bypassed
+    # with nTrials=None, the decorator gets bypassed
     # and returns the single trial array
-    cfg.pop('nTrials')
+    cfg['nTrials'] = None
     arr = ones(cfg)
     assert isinstance(arr, np.ndarray)
     assert arr.shape == (cfg.nSamples, cfg.nChannels)
@@ -58,8 +58,14 @@ class TestSynthData:
         """Without seed set, the data should not be identical.
            Note: This does not use collect trials.
         """
-        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=None)
-        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=None)
+        cfg = StructDict()
+        cfg.nSamples = self.nSamples
+        cfg.nChannels = self.nChannels
+        cfg.nTrials = None
+        cfg.seed = None
+
+        wn1 = white_noise(cfg)
+        wn2 = white_noise(cfg)
         assert isinstance(wn1, np.ndarray)
         assert isinstance(wn2, np.ndarray)
 
@@ -69,9 +75,15 @@ class TestSynthData:
         """With seed set, the data should be identical.
            Note: This does not use @collect_trials.
         """
-        seed = 42
-        wn1 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=seed)
-        wn2 = white_noise(nSamples=self.nSamples, nChannels=self.nChannels, seed=seed)
+        cfg = StructDict()
+        cfg.nSamples = self.nSamples
+        cfg.nChannels = self.nChannels
+        cfg.nTrials = None
+        cfg.seed = 42
+
+        wn1 = white_noise(cfg)
+        wn2 = white_noise(cfg)
+
         assert isinstance(wn1, np.ndarray)
         assert isinstance(wn2, np.ndarray)
 
@@ -124,8 +136,8 @@ class TestSynthData:
            Note: This does not use collect trials.
         """
         num_channels = 2
-        arn1 = AR2_network(nSamples=self.nSamples, seed=None)  # 2 channels, via default adj matrix
-        arn2 = AR2_network(nSamples=self.nSamples, seed=None)
+        arn1 = AR2_network(nSamples=self.nSamples, seed=None, nTrials=None)  # 2 channels, via default adj matrix
+        arn2 = AR2_network(nSamples=self.nSamples, seed=None, nTrials=None)
         assert isinstance(arn1, np.ndarray)
         assert isinstance(arn2, np.ndarray)
         assert arn1.shape == (self.nSamples, num_channels)
@@ -138,8 +150,8 @@ class TestSynthData:
            Note: This does not use collect trials.
         """
         seed = 42
-        arn1 = AR2_network(nSamples=self.nSamples, seed=seed, seed_per_trial=False)
-        arn2 = AR2_network(nSamples=self.nSamples, seed=seed, seed_per_trial=False)
+        arn1 = AR2_network(nSamples=self.nSamples, seed=seed, seed_per_trial=False, nTrials=None)
+        arn2 = AR2_network(nSamples=self.nSamples, seed=seed, seed_per_trial=False, nTrials=None)
 
         assert np.allclose(arn1, arn2)
 

--- a/syncopy/tests/test_timelockanalysis.py
+++ b/syncopy/tests/test_timelockanalysis.py
@@ -24,7 +24,7 @@ class TestTimelockanalysis:
 
     # create simple white noise
     # "real" data gets created for semantic test
-    adata = synthdata.white_noise(nTrials, samplerate=fs,
+    adata = synthdata.white_noise(nTrials=nTrials, samplerate=fs,
                                   nSamples=nSamples,
                                   nChannels=nChannels,
                                   seed=42)


### PR DESCRIPTION
Changes Summary
----------------
- now every `spy.synthdata` function as a documented `nTrials` signature entry
- to produce only numpy arrays, use `nTrials=None`


Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
