### PR TITLE
` spy.concat` and arithmetic np broadcast

### DIFF
--- a/syncopy/datatype/__init__.py
+++ b/syncopy/datatype/__init__.py
@@ -13,6 +13,7 @@ from .methods.selectdata import *
 from .methods.show import *
 from .methods.copy import *
 from .methods.redefinetrial import *
+from .methods.concat import *
 from .util import *
 
 # Populate local __all__ namespace
@@ -26,3 +27,4 @@ __all__.extend(methods.selectdata.__all__)
 __all__.extend(methods.show.__all__)
 __all__.extend(methods.copy.__all__)
 __all__.extend(methods.redefinetrial.__all__)
+__all__.extend(methods.concat.__all__)

--- a/syncopy/datatype/methods/arithmetic.py
+++ b/syncopy/datatype/methods/arithmetic.py
@@ -9,14 +9,10 @@ import h5py
 import dask.distributed as dd
 
 # Local imports
-from syncopy import __acme__
 from syncopy.shared.parsers import data_parser
-from syncopy.shared.errors import SPYValueError, SPYTypeError, SPYWarning, SPYInfo
+from syncopy.shared.errors import SPYValueError, SPYTypeError, SPYWarning
 from syncopy.shared.computational_routine import ComputationalRoutine
 from syncopy.shared.kwarg_decorators import process_io, detect_parallel_client
-
-if __acme__:
-    import dask.distributed as dd
 
 __all__ = []
 
@@ -368,7 +364,7 @@ def _perform_computation(baseObj,
     else:
         raise SPYValueError("supported arithmetic operator", actual=operator)
 
-    # If ACME is available, try to attach (already running) parallel computing client
+    # try to attach (already running) parallel computing client
     parallel = False
     try:
         dd.get_client()

--- a/syncopy/datatype/methods/arithmetic.py
+++ b/syncopy/datatype/methods/arithmetic.py
@@ -179,7 +179,7 @@ def _parse_input(obj1, obj2, operator):
         opres_type = np.result_type(*(trl.dtype for trl in baseTrials), operand.dtype)
 
         # Ensure shapes of all trials match up, according to NumPy broadcasting rules
-        for trl in baseTrials:        
+        for trl in baseTrials:
             try:
                 np.broadcast_shapes(trl.shape, operand.shape)
             except ValueError:
@@ -190,11 +190,6 @@ def _parse_input(obj1, obj2, operator):
         # No more info needed, the array is the only quantity we need
         operand_dat = operand
         operand_idxs = None
-
-        # All good, nevertheless warn of potential havoc this operation may cause...
-        msg = "Performing arithmetic with NumPy arrays may cause inconsistency " +\
-            "in Syncopy objects (channels, samplerate, trialdefintions etc.)"
-        SPYWarning(msg, caller=operator)
 
     # Operand is another Syncopy object
     elif "BaseData" in str(operand.__class__.__mro__):

--- a/syncopy/datatype/methods/concat.py
+++ b/syncopy/datatype/methods/concat.py
@@ -35,14 +35,17 @@ def concat(spy_obj1, spy_obj2, dim='channel'):
        The concatenation dimension
     """
 
+    # -- sanity checks --
+
     if not issubclass(spy_obj1.__class__, ContinuousData):
         raise SPYTypeError(spy_obj1, 'spy_obj1', 'continuous data type')
 
     data_parser(spy_obj1, empty=False)
     data_parser(spy_obj2, empty=False)
 
+    # catches also differing classes
     if spy_obj1.dimord != spy_obj2.dimord:
-        raise SPYValueError("objects with same dimensional layout", 'spy object dimensions',
+        raise SPYValueError("objects with equal dimensional layout", 'spy object dimensions',
                             f"{spy_obj1.dimord} and {spy_obj2.dimord}")
 
     if dim not in spy_obj1.dimord:
@@ -53,6 +56,15 @@ def concat(spy_obj1, spy_obj2, dim='channel'):
 
     concat_axis = spy_obj1.dimord.index(dim)
 
+    # check shapes
+    shape_zip = zip(spy_obj1.data.shape, spy_obj2.data.shape)
+    for axis, (s1, s2) in enumerate(shape_zip):
+        if axis != concat_axis and s1 != s2:
+            raise SPYValueError("objects with matching shapes", 'spy objects',
+                                f"{spy_obj1.data.shape}  and {spy_obj2.data.shape}"
+                                )
+
+    # new size of the concatenation axis/dimension
     # this works for `time`, `channel`, `freq` and even `trials`
     new_size = len(getattr(spy_obj1, dim)) + len(getattr(spy_obj2, dim))
 

--- a/syncopy/datatype/methods/concat.py
+++ b/syncopy/datatype/methods/concat.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+#
+# Syncopy object concatenation
+#
+
+# Builtin/3rd party package imports
+import numpy as np
+import h5py
+import dask.distributed as dd
+
+# Local imports
+from syncopy import __acme__
+from syncopy.datatype.continuous_data import ContinuousData
+from syncopy.shared.parsers import data_parser
+from syncopy.shared.errors import SPYValueError, SPYTypeError, SPYWarning, SPYInfo
+from syncopy.shared.computational_routine import ComputationalRoutine
+from syncopy.shared.kwarg_decorators import process_io, detect_parallel_client
+
+import dask.distributed as dd
+
+__all__ = ['concat']
+
+
+def concat(spy_obj1, spy_obj2, dim='channel'):
+    """
+    Concatenate two Syncopy data objects trial-by-trial along `dim` axis.
+
+    Only `channel` axis supported at the moment!
+
+    Parameters
+    ----------
+    spy_obj1 : Syncopy data object
+    spy_obj1 : Syncopy data object
+    dim : str
+       The concatenation dimension
+    """
+
+    if not issubclass(spy_obj1.__class__, ContinuousData):
+        raise SPYTypeError(spy_obj1, 'spy_obj1', 'continuous data type')
+
+    data_parser(spy_obj1, empty=False)
+    data_parser(spy_obj2, empty=False)
+
+    if spy_obj1.dimord != spy_obj2.dimord:
+        raise SPYValueError("objects with same dimensional layout", 'spy object dimensions',
+                            f"{spy_obj1.dimord} and {spy_obj2.dimord}")
+
+    if dim not in spy_obj1.dimord:
+        raise SPYValueError(f"object which has a `{dim}` dimension", 'spy_obj1.dimord', f"{spy_obj1.dimord}")
+
+    if dim != 'channel':
+        raise NotImplementedError("Only `channel` concatenation supported atm")
+
+    concat_axis = spy_obj1.dimord.index(dim)
+
+    # this works for `time`, `channel`, `freq` and even `trials`
+    new_size = len(getattr(spy_obj1, dim)) + len(getattr(spy_obj2, dim))
+
+    # these get distributed over the cF calls (one for each) to index the trials of the 2nd object
+    obj2_idxs = [spy_obj2._preview_trial(trlno).idx for trlno in range(len(spy_obj2.trials))]
+
+    # Create output object
+    result = spy_obj1.__class__(dimord=spy_obj1.dimord)
+
+    parallel = False
+
+    try:
+        dd.get_client()
+        parallel = True
+    except ValueError:
+        parallel = False
+
+    CR = SpyConcat(obj2_idxs,  # get unpacked to `trl2_idx` for each concat_cF
+                   hdf5_path=spy_obj2.filename,
+                   axis=concat_axis,
+                   new_size=new_size)
+
+    CR.initialize(spy_obj1,
+                  result._stackingDim,
+                  chan_per_worker=None,
+                  keeptrials=True)
+    log_dict = {
+        "obj1": spy_obj1.filename,
+        "obj2": spy_obj2.filename,
+        "dim": dim
+        }
+
+    CR.compute(spy_obj1, result, parallel=parallel, log_dict=log_dict)
+
+    return result
+
+
+@process_io
+def concat_cF(trl1_dat, trl2_idx, hdf5_path=None, axis=-1, new_size=None,
+              noCompute=False, chunkShape=None):
+    """
+    Concatenate 2 trials along `axis`
+
+    Parameters
+    ----------
+    trl1_dat : :class:`numpy.ndarray`
+        Trial data
+    trl2_idx : tuple
+        A tuple of indices pointing to the 2nd trial
+    hdf5_path : str
+        Path to the backing hdf5 dataset, providing the 2nd trial via `trl2_idx`
+    new_size : int
+        New size along the concatenation axis
+    noCompute : bool
+        Preprocessing flag. If `True`, do not perform actual calculation but
+        instead return expected shape and :class:`numpy.dtype` of output
+        array.
+    chunkShape : None or tuple
+        If not `None`, represents shape of output
+
+    Returns
+    -------
+    res : :class:`numpy.ndarray`
+        Concatenate result
+
+    Notes
+    -----
+    This method is intended to be used as :meth:`~syncopy.shared.computational_routine.ComputationalRoutine.computeFunction`
+    inside a :class:`~syncopy.shared.computational_routine.ComputationalRoutine`.
+    Thus, input parameters are presumed to be forwarded from a parent metafunction.
+    Consequently, this function does **not** perform any error checking and operates
+    under the assumption that all inputs have been externally validated and cross-checked.
+
+    See also
+    --------
+    _perform_computation : execute arithmetic operation
+    SpyArithmetic : :class:`~syncopy.shared.computational_routine.ComputationalRoutine` subclass
+    """
+
+    if noCompute:
+        new_shape = np.array(trl1_dat.shape)
+        new_shape[axis] = new_size
+        return tuple(new_shape), trl1_dat.dtype
+
+    # get the 2nd trial as array
+    with h5py.File(hdf5_path, "r") as h5file:
+        trl2_dat = h5file['data'][trl2_idx]
+
+    return np.concatenate([trl1_dat, trl2_dat], axis=axis)
+
+
+class SpyConcat(ComputationalRoutine):
+    """
+    Compute class for performing concatenation of Syncopy objects
+
+    Sub-class of :class:`~syncopy.shared.computational_routine.ComputationalRoutine`,
+    see :doc:`/developer/compute_kernels` for technical details on Syncopy's compute
+    classes and metafunctions.
+    """
+
+    computeFunction = staticmethod(concat_cF)
+
+    def process_metadata(self, baseObj, out):
+
+        # -- only channel concat atm --
+
+        # Get/set dimensional attributes with the help of a selection
+        if baseObj.selection is None:
+            revert = True
+            baseObj.selectdata(inplace=True)
+        else:
+            revert = False
+
+        concat_dim = baseObj.dimord[self.cfg['axis']]
+
+        # Get/set timing-related selection modifiers
+        out.trialdefinition = baseObj.selection.trialdefinition
+        if baseObj.selection._samplerate:
+            out.samplerate = baseObj.samplerate
+
+        for prop in [prop for prop in baseObj.selection._dimProps if prop != concat_dim]:
+            selection = getattr(baseObj.selection, prop)
+            if selection is not None:
+                if np.issubdtype(type(selection), np.number):
+                    selection = [selection]
+                setattr(out, prop, getattr(baseObj, prop)[selection])
+
+        if revert:
+            baseObj.selection = None

--- a/syncopy/tests/test_basedata.py
+++ b/syncopy/tests/test_basedata.py
@@ -269,6 +269,29 @@ class TestBaseData():
             complexArr = np.complex64(dummy.trials[0])
             complexNum = 3 + 4j
 
+            print(dummy.trials[0].shape, dclass)
+
+            # test that NumPy broadcasting rules are respected
+            trl_shape = dummy.trials[0].shape
+            # 1st dimension is different from last in `self.data`
+            assert trl_shape[0] != trl_shape[-1]
+
+            vec_ok = np.zeros(trl_shape[-1])
+            res = dummy * vec_ok
+            # everything zeroed
+            assert np.allclose(res.data[()], 0)
+
+            with pytest.raises(SPYValueError, match="Invalid value of `operand`"):
+                vec_not_ok = np.zeros(trl_shape[0])
+                _ = dummy * vec_not_ok
+
+            # array multiplication works as usual trial-by-trial
+            arr = np.zeros(np.prod(trl_shape)).reshape(trl_shape)
+            res = dummy * arr
+
+            # everything zeroed
+            assert np.allclose(res.data[()], 0)
+
             # Start w/the one operator that does not handle zeros well...
             with pytest.raises(SPYValueError) as spyval:
                 _ = dummy / 0

--- a/syncopy/tests/test_basedata.py
+++ b/syncopy/tests/test_basedata.py
@@ -269,9 +269,8 @@ class TestBaseData():
             complexArr = np.complex64(dummy.trials[0])
             complexNum = 3 + 4j
 
-            print(dummy.trials[0].shape, dclass)
+            # -- test that NumPy broadcasting rules are respected --
 
-            # test that NumPy broadcasting rules are respected
             trl_shape = dummy.trials[0].shape
             # 1st dimension is different from last in `self.data`
             assert trl_shape[0] != trl_shape[-1]
@@ -291,6 +290,8 @@ class TestBaseData():
 
             # everything zeroed
             assert np.allclose(res.data[()], 0)
+
+            # -- test exceptions  --
 
             # Start w/the one operator that does not handle zeros well...
             with pytest.raises(SPYValueError) as spyval:

--- a/syncopy/tests/test_concat.py
+++ b/syncopy/tests/test_concat.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# Test spy.concat function
+#
+
+import pytest
+import numpy as np
+
+# Local imports
+import syncopy as spy
+from syncopy.shared.errors import SPYTypeError, SPYValueError
+
+
+class TestConcat:
+
+    nTrials = 10
+    nSamples = 100
+    nChannels = 2
+
+    nFreq = 5
+    nTaper = 4
+
+    def test_ad_concat(self):
+
+        arr = np.zeros((self.nSamples, self.nChannels))
+        adata = spy.AnalogData(data=[arr for _ in range(self.nTrials)],
+                               samplerate=10)
+
+        # create 3 channel 2nd data object
+
+        adata2 = spy.AnalogData(data=[np.zeros((self.nSamples, 3)) for _ in range(self.nTrials)],
+                                samplerate=10)
+
+        res = spy.concat(adata, adata2)
+
+        assert isinstance(res, spy.AnalogData)
+        assert len(res.trials) == len(adata.trials)
+        assert len(res.channel) == len(adata.channel) + len(adata2.channel)
+        # check total size
+        assert res.data.size == adata.data.size + 3 * self.nSamples * self.nTrials
+
+    def test_sd_concat(self):
+
+        # -- SpectralData with non-standard dimord --
+
+        arr = np.zeros((self.nSamples, self.nChannels, self.nTaper, self.nFreq))
+        sdata = spy.SpectralData(data=[arr for _ in range(self.nTrials)],
+                                 samplerate=10,
+                                 dimord=['time', 'channel', 'taper', 'freq'])
+
+        # create 3 channel 2nd data object
+
+        arr = np.zeros((self.nSamples, 3, self.nTaper, self.nFreq))
+        sdata2 = spy.SpectralData(data=[arr for _ in range(self.nTrials)],
+                                  samplerate=10,
+                                  dimord=['time', 'channel', 'taper', 'freq'])
+
+        res = spy.concat(sdata, sdata2)
+
+        assert isinstance(res, spy.SpectralData)
+        assert len(res.trials) == len(sdata.trials)
+        assert len(res.channel) == len(sdata.channel) + len(sdata2.channel)
+        # check total size
+        assert res.data.size == sdata.data.size + 3 * self.nSamples * self.nTrials * self.nTaper * self.nFreq
+
+    def test_exceptions(self):
+
+        # non matching data types
+        adata = spy.AnalogData(data=np.zeros((10, 2)), samplerate=2)
+        sdata = spy.SpectralData(data=np.zeros((10, 2, 2, 2)), samplerate=2)
+
+        with pytest.raises(SPYValueError, match='expected objects with equal dimensional layout'):
+            spy.concat(adata, sdata)
+
+        # non matching dimord
+        adata2 = spy.AnalogData(data=np.zeros((10, 2)), samplerate=2,
+                                dimord=['channel', 'time'])
+
+        with pytest.raises(SPYValueError, match='expected objects with equal dimensional layout'):
+            spy.concat(adata, adata2)
+
+        # dim not in dimord
+        with pytest.raises(SPYValueError, match='object which has a `sth` dimension'):
+            spy.concat(adata, adata, dim='sth')
+
+        # only channel supported atm
+        with pytest.raises(NotImplementedError, match='Only `channel`'):
+            spy.concat(adata, adata, dim='time')
+
+        # objects don't have the same size along remaining axes
+        adata3 = spy.AnalogData(data=np.zeros((12, 2)), samplerate=3)
+        with pytest.raises(SPYValueError, match='matching shapes'):
+            spy.concat(adata, adata3, dim='channel')
+        
+
+if __name__ == '__main__':
+
+    T1 = TestConcat()

--- a/syncopy/tests/test_continuousdata.py
+++ b/syncopy/tests/test_continuousdata.py
@@ -397,8 +397,7 @@ class TestAnalogData():
     def test_parallel(self, testcluster):
         # repeat selected test w/parallel processing engine
         client = dd.Client(testcluster)
-        slow_tests = ["test_dataselection",
-                      "test_ang_arithmetic"]
+        slow_tests = ["test_ang_arithmetic"]
         for test in slow_tests:
             getattr(self, test)()
             flush_local_cluster(testcluster)


### PR DESCRIPTION
Changes Summary
----------------
- new global `spy.concat` to concatenate trial-by-trial
- arithmetics now respect numpy broadcasting rules (mult. with a vector is fine)

Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
