### PR TITLE
FIX: manually install iniconfig on macos Gitlab runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,6 +99,7 @@ m1macos:
     - conda env update --name syncopy-m1macos --file syncopy.yml --prune
     - conda activate syncopy-m1macos
     - conda install importlib_resources
+    - conda install -c conda-forge iniconfig
     - conda install pynwb=2.3.2 -c conda-forge
     - export PYTHONPATH=$CI_PROJECT_DIR
     - pytest -ra -k 'not parallel'


### PR DESCRIPTION
Changes Summary
----------------
- manually install iniconfig on macos Gitlab runners


Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
