### PR TITLE
Repair n taper defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fix SpikeData string rep, #511
+- corrected slepian/dpss default taper settings, #559
 
 
 ## [2023.05]

--- a/syncopy/connectivity/connectivity_analysis.py
+++ b/syncopy/connectivity/connectivity_analysis.py
@@ -645,6 +645,13 @@ def cross_spectra(
         foi = freqs
 
     # sanitize taper selection and retrieve dpss settings
+
+    if data.selection is None:
+        sinfo = data.sampleinfo
+    else:
+        sinfo = data.selection.trialdefinition[:, :2]
+    lenTrials = np.diff(sinfo).squeeze()
+
     taper, taper_opt = process_taper(
         taper,
         taper_opt,
@@ -653,7 +660,7 @@ def cross_spectra(
         keeptapers=False,  # ST_CSD's always average tapers
         foimax=foi.max(),
         samplerate=data.samplerate,
-        nSamples=nSamples,
+        nSamples=lenTrials.mean(),
         output="pow",
     )  # ST_CSD's always have this unit/norm
 

--- a/syncopy/shared/input_processors.py
+++ b/syncopy/shared/input_processors.py
@@ -312,7 +312,7 @@ def process_taper(
 
         # --- minimal smoothing bandwidth ---
         # --- such that Kmax/nTaper is at least 1
-        minBw = 2 * samplerate / nSamples
+        minBw = samplerate / nSamples
         # -----------------------------------
 
         # --- maximal smoothing bandwidth ---

--- a/syncopy/specest/freqanalysis.py
+++ b/syncopy/specest/freqanalysis.py
@@ -627,7 +627,7 @@ def freqanalysis(
             keeptapers,
             foimax=foi.max(),
             samplerate=data.samplerate,
-            nSamples=minSampleNum,
+            nSamples=lenTrials.mean(),   # best we can do here
             output=output,
         )
 

--- a/syncopy/tests/test_connectivity.py
+++ b/syncopy/tests/test_connectivity.py
@@ -772,7 +772,7 @@ class TestPPC:
 
     # spectral analysis
     cfg = spy.StructDict()
-    cfg.tapsmofrq = 1.5
+    cfg.tapsmofrq = 2.
     cfg.foilim = [5, 60]
 
     spec = spy.freqanalysis(data, cfg, output="fourier", keeptapers=True)

--- a/syncopy/tests/test_plotting.py
+++ b/syncopy/tests/test_plotting.py
@@ -136,7 +136,7 @@ class TestSpectralPlotting:
 
     nTrials = 10
     nChannels = 4
-    nSamples = 300
+    nSamples = 500
     AdjMat = np.zeros((nChannels, nChannels))
     adata = synthdata.ar2_network(nTrials=nTrials, AdjMat=AdjMat, nSamples=nSamples)
 
@@ -151,9 +151,9 @@ class TestSpectralPlotting:
     # all trials are equal
     toi_min, toi_max = adata.time[0][0], adata.time[0][-1]
 
-    spec_fft = spy.freqanalysis(adata, tapsmofrq=1)
+    spec_fft = spy.freqanalysis(adata, tapsmofrq=2)
     spec_fft_imag = spy.freqanalysis(adata, output="imag")
-    spec_fft_mtm = spy.freqanalysis(adata, tapsmofrq=1, keeptapers=True)
+    spec_fft_mtm = spy.freqanalysis(adata, tapsmofrq=3, keeptapers=True)
     spec_fft_complex = spy.freqanalysis(adata, output="fourier")
 
     spec_wlet = spy.freqanalysis(adata, method="wavelet", foi=np.arange(0, 400, step=4))

--- a/syncopy/tests/test_statistics.py
+++ b/syncopy/tests/test_statistics.py
@@ -251,27 +251,11 @@ class TestSumStatistics:
         )
 
         # test also taper averaging
-        spec = spy.freqanalysis(adata, foilim=[0, 100], output="fourier", tapsmofrq=0.5, keeptapers=True)
+        spec = spy.freqanalysis(adata, foilim=[0, 100], output="fourier", tapsmofrq=1, keeptapers=True)
 
         # -- calculate itc --
         itc = spy.itc(spec)
         tf_itc = spy.itc(tf_spec)
-
-        assert isinstance(tf_itc, spy.SpectralData)
-
-        assert np.all(np.imag(itc.data[()]) == 0)
-        assert itc.data[()].max() <= 1
-        assert itc.data[()].min() >= 0
-
-        # high itc around the in phase 60Hz
-        assert np.all(itc.show(frequency=60) > 0.6)
-        # low (time averaged) itc around the drifters
-        assert np.all(itc.show(frequency=30) < 0.25)
-
-        assert np.all(np.imag(tf_itc.data[()]) == 0)
-        assert tf_itc.data[()].max() <= 1
-        assert tf_itc.data[()].min() >= 0
-        assert np.allclose(tf_itc.time[0], tf_spec.time[0])
 
         if do_plot:
 
@@ -298,6 +282,23 @@ class TestSumStatistics:
                 ax.plot(tf_itc.time[0], itc_profile, label=f"{frq}Hz")
             ax.legend()
             ax.set_title("time dependent ITC")
+
+        assert isinstance(tf_itc, spy.SpectralData)
+
+        assert np.all(np.imag(itc.data[()]) == 0)
+        assert itc.data[()].max() <= 1
+        assert itc.data[()].min() >= 0
+
+        # high itc around the in phase 60Hz
+        assert np.all(itc.show(frequency=60) > 0.6)
+        # low (time averaged) itc around the drifters
+        assert np.all(itc.show(frequency=30) < 0.25)
+
+        assert np.all(np.imag(tf_itc.data[()]) == 0)
+        assert tf_itc.data[()].max() <= 1
+        assert tf_itc.data[()].min() >= 0
+        assert np.allclose(tf_itc.time[0], tf_spec.time[0])
+
 
 
 class TestJackknife:


### PR DESCRIPTION
Changes Summary
----------------
- comparison with FT unmasked errors in the default Slepian/multi-taper settings
- minimal bandwidth was a factor of 2 too big
- dpss settings were wrongly calculated from padded signal lengths


Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
