### PR TITLE
563 add channelcmb parameter to connectivityanalysis frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file.
 
 
+## Current WIP
+
+### NEW
+- Add channelcmb parameter to connectivityanalysis frontend to allow computing connectivity measures for a subset of the channels only, #563
+
+### Changed
+
+### Fixed
+
+
+
 ## [2023.07]
 
 ### NEW

--- a/syncopy/connectivity/ST_compRoutines.py
+++ b/syncopy/connectivity/ST_compRoutines.py
@@ -76,9 +76,6 @@ def spectral_dyadic_product_cF(specs,
 
     """
 
-    print(send_idx, send_N)
-    print(rec_idx, rec_N)
-
     # default dimord for SpectralData is ['time', 'taper', 'freq', 'channel']
     nTime = specs.shape[0]
     nFreq = specs.shape[2]
@@ -98,8 +95,6 @@ def spectral_dyadic_product_cF(specs,
         # dyadic product along sender/receiver channel axes
         # result has shape (nTime, nTapers x nFreq x nChannels x nChannels)
         CS_ij = specs[..., send_idx, np.newaxis] * specs[..., np.newaxis, rec_idx].conj()
-        print(CS_ij.shape, rec_idx, specs.shape)
-        print(specs[..., send_idx, np.newaxis].shape, specs[..., np.newaxis, rec_idx].shape)
 
     # all channel comb, full dyadic channel product
     else:

--- a/syncopy/connectivity/ST_compRoutines.py
+++ b/syncopy/connectivity/ST_compRoutines.py
@@ -95,7 +95,7 @@ def spectral_dyadic_product_cF(specs,
         if noCompute:
             return outShape, spectralDTypes["fourier"]
 
-        # dyadic product along channel axes
+        # dyadic product along sender/receiver channel axes
         # result has shape (nTime, nTapers x nFreq x nChannels x nChannels)
         CS_ij = specs[..., send_idx, np.newaxis] * specs[..., np.newaxis, rec_idx].conj()
         print(CS_ij.shape, rec_idx, specs.shape)
@@ -153,6 +153,10 @@ class SpectralDyadicProduct(ComputationalRoutine):
 
         time_axis = np.any(np.diff(data.trialdefinition)[:, 0] != 1)
         propagate_properties(data, out, self.keeptrials, time_axis)
+        # digest `channelcmb` parameter, conflicting channel selection got ruled out!
+        if 'send_idx' in self.cfg:
+            out.channel_i = data.channel[self.cfg['send_idx']]
+            out.channel_j = data.channel[self.cfg['rec_idx']]
         out.freq = data.freq
 
 

--- a/syncopy/connectivity/ST_compRoutines.py
+++ b/syncopy/connectivity/ST_compRoutines.py
@@ -154,7 +154,7 @@ class SpectralDyadicProduct(ComputationalRoutine):
         time_axis = np.any(np.diff(data.trialdefinition)[:, 0] != 1)
         propagate_properties(data, out, self.keeptrials, time_axis)
         # digest `channelcmb` parameter, conflicting channel selection got ruled out!
-        if 'send_idx' in self.cfg:
+        if self.cfg['send_idx'] is not None:
             out.channel_i = data.channel[self.cfg['send_idx']]
             out.channel_j = data.channel[self.cfg['rec_idx']]
         out.freq = data.freq

--- a/syncopy/connectivity/ST_compRoutines.py
+++ b/syncopy/connectivity/ST_compRoutines.py
@@ -27,7 +27,13 @@ from syncopy.shared.kwarg_decorators import process_io
 
 
 @process_io
-def spectral_dyadic_product_cF(specs, chunkShape=None, noCompute=False):
+def spectral_dyadic_product_cF(specs,
+                               send_idx=None,
+                               send_N=None,
+                               rec_idx=None,
+                               rec_N=None,
+                               chunkShape=None,
+                               noCompute=False):
     """
     Single trial cross spectra directly from complex power spectra,
     hence no Fourier transforms are needed and all what is
@@ -70,21 +76,45 @@ def spectral_dyadic_product_cF(specs, chunkShape=None, noCompute=False):
 
     """
 
+    print(send_idx, send_N)
+    print(rec_idx, rec_N)
+
     # default dimord for SpectralData is ['time', 'taper', 'freq', 'channel']
     nTime = specs.shape[0]
     nFreq = specs.shape[2]
-    nChannels = specs.shape[3]
 
-    # we always average over tapers here
-    outShape = (nTime, nFreq, nChannels, nChannels)
+    # subset of channel combinations?
+    if send_idx is not None:
+        nChannels1 = send_N
+        nChannels2 = rec_N
 
-    # cross spectra are complex, input gets checked in frontend!
-    if noCompute:
-        return outShape, spectralDTypes["fourier"]
+        # we always average over tapers here
+        outShape = (nTime, nFreq, nChannels1, nChannels2)
 
-    # dyadic product along channel axes
-    # result has shape (nTime, nTapers x nFreq x nChannels x nChannels)
-    CS_ij = specs[..., np.newaxis] * specs[..., np.newaxis, :].conj()
+        # cross spectra are complex, input gets checked in frontend!
+        if noCompute:
+            return outShape, spectralDTypes["fourier"]
+
+        # dyadic product along channel axes
+        # result has shape (nTime, nTapers x nFreq x nChannels x nChannels)
+        CS_ij = specs[..., send_idx, np.newaxis] * specs[..., np.newaxis, rec_idx].conj()
+        print(CS_ij.shape, rec_idx, specs.shape)
+        print(specs[..., send_idx, np.newaxis].shape, specs[..., np.newaxis, rec_idx].shape)
+
+    # all channel comb, full dyadic channel product
+    else:
+        nChannels = specs.shape[3]
+
+        # we always average over tapers here
+        outShape = (nTime, nFreq, nChannels, nChannels)
+
+        # cross spectra are complex, input gets checked in frontend!
+        if noCompute:
+            return outShape, spectralDTypes["fourier"]
+
+        # dyadic product along channel axes
+        # result has shape (nTime, nTapers x nFreq x nChannels x nChannels)
+        CS_ij = specs[..., np.newaxis] * specs[..., np.newaxis, :].conj()
 
     # now average tapers
     # result has shape (nTime x nFreq x nChannels x nChannels)

--- a/syncopy/connectivity/connectivity_analysis.py
+++ b/syncopy/connectivity/connectivity_analysis.py
@@ -333,7 +333,7 @@ def connectivityanalysis(
 
         # fix type, either channel name (str) or index (int)
         cmb_type = type(senders[0])
-        chan_avail = data.channel if cmb_type == 'str' else range(len(data.channel))
+        chan_avail = data.channel if cmb_type == str else range(len(data.channel))
 
         # repeat now with type check
         sequence_parser(senders, varname="channelcmb[senders,", content_type=cmb_type)
@@ -682,8 +682,6 @@ def connectivityanalysis(
                     with h5py.File(fname, "r+") as h5file:
                         dset = h5file['data']
 
-                        print(idx1, idx2, ch1, ch2)
-                        print(pair_out.data.shape, dset.shape)
                         # only direction sender(ch1) -> receiver(ch2)
                         dset[0, :, idx1, idx2] = pair_out.data[0, :, 0, 1]
 

--- a/syncopy/datatype/selector.py
+++ b/syncopy/datatype/selector.py
@@ -735,6 +735,15 @@ class Selector:
                         if steps.min() == steps.max() == 1:
                             idxList = slice(idxList[0], idxList[-1] + 1, 1)
 
+                    if isinstance(idxList, list) and selectkey in [
+                            "channel_i",
+                            "channel_j"]:
+
+                        # why only for CrossSpectralData a 1-element
+                        # selection index list gets reduced to an int?!
+                        if len(idxList) == 1:
+                            idxList = idxList[0]
+
                     setattr(self, selector, idxList)
 
         else:

--- a/syncopy/datatype/selector.py
+++ b/syncopy/datatype/selector.py
@@ -735,17 +735,6 @@ class Selector:
                         if steps.min() == steps.max() == 1:
                             idxList = slice(idxList[0], idxList[-1] + 1, 1)
 
-                    # be careful w/pairwise list-channel selections in `CrossSpectralData` objects
-                    # (that could not be converted to slices above)
-                    if isinstance(idxList, list) and selectkey in [
-                        "channel_i",
-                        "channel_j",
-                    ]:
-                        if len(idxList) > 1:
-                            err = "Unordered (low to high) or non-contiguous multi-channel-pair selections not supported"
-                            raise NotImplementedError(err)
-                        idxList = idxList[0]
-
                     setattr(self, selector, idxList)
 
         else:

--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -1190,8 +1190,8 @@ def propagate_properties(in_data, out_data, keeptrials=True, time_axis=False):
     # from one channel to cross-channel data
     elif (is_Analog(in_data) or is_Spectral(in_data)) and is_CrossSpectral(out_data):
         chanSec = in_data.selection.channel
-        out_data.channel_i = np.array(in_data.channel[chanSec])
-        out_data.channel_j = np.array(in_data.channel[chanSec])
+        # out_data.channel_i = np.array(in_data.channel[chanSec])
+        # out_data.channel_j = np.array(in_data.channel[chanSec])
 
     # --- time and trialdefinition ---
 

--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -1190,11 +1190,13 @@ def propagate_properties(in_data, out_data, keeptrials=True, time_axis=False):
     # from one channel to cross-channel data
     elif (is_Analog(in_data) or is_Spectral(in_data)) and is_CrossSpectral(out_data):
         chanSec = in_data.selection.channel
-        # in case of rectangular result, `channelcmb` got used
-        # and channel labels get attached within the respective CR
-        if out_data.data.shape[-2] == out_data.data.shape[-1]:
+        nChan = len(in_data.channel)
+        if out_data.data.shape[-2:] == (nChan, nChan):
             out_data.channel_i = np.array(in_data.channel[chanSec])
             out_data.channel_j = np.array(in_data.channel[chanSec])
+
+        # else `channelcmb` got used and channel labels
+        # get attached within the respective CR
 
     # --- time and trialdefinition ---
 

--- a/syncopy/shared/computational_routine.py
+++ b/syncopy/shared/computational_routine.py
@@ -1190,8 +1190,11 @@ def propagate_properties(in_data, out_data, keeptrials=True, time_axis=False):
     # from one channel to cross-channel data
     elif (is_Analog(in_data) or is_Spectral(in_data)) and is_CrossSpectral(out_data):
         chanSec = in_data.selection.channel
-        # out_data.channel_i = np.array(in_data.channel[chanSec])
-        # out_data.channel_j = np.array(in_data.channel[chanSec])
+        # in case of rectangular result, `channelcmb` got used
+        # and channel labels get attached within the respective CR
+        if out_data.data.shape[-2] == out_data.data.shape[-1]:
+            out_data.channel_i = np.array(in_data.channel[chanSec])
+            out_data.channel_j = np.array(in_data.channel[chanSec])
 
     # --- time and trialdefinition ---
 

--- a/syncopy/shared/parsers.py
+++ b/syncopy/shared/parsers.py
@@ -785,4 +785,4 @@ def sequence_parser(sequence, content_type=None, varname=""):
         for element in sequence:
             if not isinstance(element, content_type):
                 expected = content_type.__name__
-                raise SPYTypeError(element, varname=f"element of {varname}", expected=expected)
+                raise SPYTypeError(element, varname=f"item of {varname}", expected=expected)

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -367,11 +367,11 @@ class TestCrossSpectralSelections:
         # each selection test is a 2-tuple: (selection kwargs, dict with same kws and the idx "solutions")
         valid_selections = [
             (
-                {"channel_i": [0, 1], "channel_j": [1, 2], "latency": [1, 2]},
+                {"channel_i": [0, 1], "channel_j": [0, 2], "latency": [1, 2]},
                 # the 'solutions'
                 {
                     "channel_i": slice(0, 2, 1),
-                    "channel_j": slice(1, 3, 1),
+                    "channel_j": [0, 2],
                     "latency": 3 * [slice(0, 3, 1)],
                 },
             ),
@@ -400,19 +400,9 @@ class TestCrossSpectralSelections:
         # each selection test is a 3-tuple: (selection kwargs, Error, error message sub-string)
         invalid_selections = [
             (
-                {"channel_i": [0, 2]},
-                NotImplementedError,
-                r"Unordered \(low to high\) or non-contiguous multi-channel-pair selections not supported",
-            ),
-            (
-                {"channel_i": [1, 0]},
-                NotImplementedError,
-                r"Unordered \(low to high\) or non-contiguous multi-channel-pair selections not supported",
-            ),
-            (
-                {"channel_j": ["channel3", "channel1"]},
-                NotImplementedError,
-                r"Unordered \(low to high\) or non-contiguous multi-channel-pair selections not supported",
+                {"channel_i": [0, 4]},
+                SPYValueError,
+                r"existing names or indices"
             ),
         ]
 


### PR DESCRIPTION
Changes Summary
----------------
- new parameter `channelcmb=[senders, receivers]` for `spy.connectivityanalysis`
- `selectdata` now allow non-contiguous and unorderd `channel_i` and `channel_j` selections, there was no reason apparent why this was not allowed before (I did not fiddle with any selection mechanics inside the `Selector`)

Now users can fine tune the channel-pairs for which to compute the connectivity measure as in FieldTrip:
 ```python
senders = [0, 3] 
receivers = [1, 5, 8]
spy.connectivityanalysis(..., channelcmb=[senders, receivers])
```
will compute only 6 pairs: (01, 05, 08, 31, 35, 38) and the resulting `CrossSpectralData` **is rectangular in the channel axes** with ` channel_i=senders` and `channel_j=receivers`. 

Note: the old way of doing a channel selection on the input:
```python
spy.connectivityanalysis(..., select={'channel': [0, 1, 3, 5, 8]})
```
would instead compute 20 pairs (+diagonal): the full dyadic (or tensor) product of those 5 channels.

### Implementation differs according to the method
#### Granger causality
- computes **all pairs individually**, so in the example above this would be 6 spectral factorizations of 2 x 2 matrices. The result gets collected into a single 1 x nFreq x 2 x 3 `CrossSpectralData` object. The factorization algorithm is most stable when only computing pairs, however for many trials/few channels it would be much more effective to compute more pairs at once. 

#### CSD/PPC
- the sender/receiver pairs get directly indexed within the cF (so the numpy arrays), and the single trial cross-spectra have rectangular shape. It was straightforward inputting this into the PPC algorithm, to compute the PPC only for the desired pairs.

#### Coherence
- rectangular single trial cross-spectra are not an easy option here, as the individual auto-spectra (diagonal in the full dyadic case) are needed for normalization. However, since computation is extremely cheap, all what is done is a simple post-selection of the `channel_i/senders` `channel_j/receivers` combinations which now is possible.

### Limitations
- only for spectral methods `('coh', 'csd', 'ppc', 'granger')`
- works only for spectral input (`SpectralData`) as re-writing the whole implicit `freqanalysis` part when inputting `AnalogData` into `connectivityanalysis` would require some bigger refactoring (design is actually bad for historic reasons)
- general inplace selections on the input are still fine of course, but channel selections don't work together with `channelcmb`

Reviewer Checklist
------------------
- [x] Are testing routines present?
- [x] Do objects in the global package namespace perform proper parsing of their input? 
- [x] Are all docstrings complete and accurate?
- [x] Is the CHANGELOG.md up to date?
