### PR TITLE
Improve serializable dict

### DIFF
--- a/syncopy/tests/test_info.py
+++ b/syncopy/tests/test_info.py
@@ -11,7 +11,7 @@ import os
 # Local imports
 import syncopy as spy
 from syncopy.shared.tools import SerializableDict
-from syncopy.shared.errors import SPYTypeError
+from syncopy.shared.errors import SPYTypeError, SPYError
 
 
 class TestInfo:
@@ -53,7 +53,7 @@ class TestInfo:
         assert len(self.ok_dict) != 0
 
         # test we're catching non-serializable dictionary entries
-        with pytest.raises(SPYTypeError, match="expected serializable data type"):
+        with pytest.raises(SPYError, match="expected serializable data type"):
             adata.info = self.ns_dict
 
         # test that we also catch non-serializable keys

--- a/syncopy/tests/test_info.py
+++ b/syncopy/tests/test_info.py
@@ -57,19 +57,11 @@ class TestInfo:
             adata.info = self.ns_dict
 
         # test that we also catch non-serializable keys
-        with pytest.raises(SPYTypeError, match="expected serializable data type"):
+        with pytest.raises(SPYError, match="expected serializable data type"):
             adata.info = self.ns_dict2
 
-        # this interestingly still does NOT work (numbers are np.float64):
-        with pytest.raises(SPYTypeError, match="expected serializable data type"):
-            adata.info["new-var"] = list(np.arange(3))
-
-        # even this.. numbers are still np.int64
-        with pytest.raises(SPYTypeError, match="expected serializable data type"):
-            adata.info["new-var"] = list(np.arange(3, dtype=int))
-
-        # this then works, hope is that users don't abuse it
-        adata.info["new-var"] = list(np.arange(3, dtype=float))
+        # this works, data types get converted from NumPy to Python scalars
+        adata.info["new-var"] = list(np.arange(3))
         assert np.allclose(adata.info["new-var"], np.arange(3))
 
     # test aux. info dict saving and loading

--- a/syncopy/tests/test_info.py
+++ b/syncopy/tests/test_info.py
@@ -54,8 +54,6 @@ class TestInfo:
 
         # test we're catching non-serializable dictionary entries
         with pytest.raises(SPYTypeError, match="expected serializable data type"):
-            adata.info["new-var"] = np.arange(3)
-        with pytest.raises(SPYTypeError, match="expected serializable data type"):
             adata.info = self.ns_dict
 
         # test that we also catch non-serializable keys

--- a/syncopy/tests/test_selectdata.py
+++ b/syncopy/tests/test_selectdata.py
@@ -12,7 +12,7 @@ import dask.distributed as dd
 
 # Local imports
 from syncopy.datatype.selector import Selector
-from syncopy.shared.errors import SPYValueError, SPYTypeError
+from syncopy.shared.errors import SPYValueError, SPYTypeError, SPYError
 from syncopy.tests.misc import flush_local_cluster
 
 import syncopy as spy
@@ -149,7 +149,7 @@ class TestAnalogSelections:
             ({"latency": "sth-wrong"}, SPYValueError, "'maxperiod'"),
             ({"trials": [-3]}, SPYValueError, "all array elements to be bound"),
             ({"trials": ["1", "6"]}, SPYValueError, "expected dtype = numeric"),
-            ({"trials": slice(2)}, SPYTypeError, "expected serializable data type"),
+            ({"trials": slice(2)}, SPYError, "expected serializable data type"),
         ]
 
         for selection in invalid_selections:
@@ -279,7 +279,7 @@ class TestSpectralSelections:
             ({"frequency": 4}, SPYValueError, "all array elements to be bounded"),
             (
                 {"frequency": slice(None)},
-                SPYTypeError,
+                SPYError,
                 "expected serializable data type",
             ),
             ({"frequency": range(20, 60)}, SPYTypeError, "expected array_like"),
@@ -533,9 +533,9 @@ class TestSpikeSelections:
                 SPYValueError,
                 "existing names or indices",
             ),
-            ({"channel": slice(None)}, SPYTypeError, "expected serializable data type"),
+            ({"channel": slice(None)}, SPYError, "expected serializable data type"),
             ({"unit": 99}, SPYValueError, "existing names or indices"),
-            ({"unit": slice(None)}, SPYTypeError, "expected serializable data type"),
+            ({"unit": slice(None)}, SPYError, "expected serializable data type"),
             (
                 {"latency": [-1, 10]},
                 SPYValueError,

--- a/syncopy/tests/test_tools.py
+++ b/syncopy/tests/test_tools.py
@@ -3,8 +3,15 @@
 # Test shared tools.
 #
 
-import syncopy as spy
+import pytest
+import numpy as np
+import json
 import copy
+
+import syncopy as spy
+from syncopy.shared.tools import SerializableDict
+from syncopy.shared.errors import SPYError
+
 
 
 class TestTools:
@@ -173,5 +180,81 @@ class TestTools:
         assert cfg.c == [1, 2, 3, 4]
 
 
+def test_serializable_dict():
+
+    dct = SerializableDict()
+
+    # check standard types
+    dct['list'] = [str(i) + 'a' for i in range(10)]
+    assert len(dct['list']) == 10
+    assert dct['list'][9] == '9a'
+
+    dct['tuple'] = tuple(dct['list'])
+    assert len(dct['tuple']) == 10
+    assert dct['tuple'][9] == '9a'
+
+    dct['str'] = 'some_string'
+    assert dct['str'] == 'some_string'
+
+    dct['list2'] = [i / 239 for i in range(10)]
+    assert len(dct['list2']) == 10
+
+    dct['dict'] = {'d1': [1, 2, 3], 'd2': 'g'}
+    assert dct['dict']['d1'] == [1, 2, 3]
+    assert dct['dict']['d2'] == 'g'
+
+    # not serializable scalars
+
+    num1 = np.int64(12)
+    num2 = np.float128(12.12)
+
+    with pytest.raises(TypeError, match="not JSON"):
+        json.dumps(num1)
+
+    # gets converted to Python scalars
+    dct['int64'] = num1
+    assert isinstance(dct['int64'], int)
+
+    with pytest.raises(TypeError, match="not JSON"):
+        json.dumps(num2)
+
+    dct['float128'] = num2
+    assert isinstance(dct['float128'], float)
+
+    # now 1-level deep sequences which are NOT
+    # directly serializable
+
+    arr = np.arange(10)
+
+    with pytest.raises(TypeError, match="not JSON"):
+        json.dumps(arr)
+
+    # converted to list of python scalars
+    dct['arr'] = arr
+    assert isinstance(dct['arr'], list)
+
+    lst = [np.int64(12), np.int64(20)]
+
+    with pytest.raises(TypeError, match="not JSON"):
+        json.dumps(lst)
+
+    dct['list64'] = lst
+    assert isinstance(dct['list64'][1], int)
+
+    # 2 level deep nesting not supported
+
+    lst2 = [[np.int64(12)]]
+
+    with pytest.raises(TypeError, match="not JSON"):
+        json.dumps(lst2)
+
+    with pytest.raises(SPYError, match="expected serializable data type"):
+        dct['nested2'] = lst2
+
+    # keys also need to be serializable
+
+    with pytest.raises(SPYError, match="Wrong type of key"):
+        dct[np.int64(12)] = 'some_string'
+    
 if __name__ == "__main__":
     T1 = TestTools()

--- a/syncopy/tests/test_tools.py
+++ b/syncopy/tests/test_tools.py
@@ -255,6 +255,6 @@ def test_serializable_dict():
 
     with pytest.raises(SPYError, match="Wrong type of key"):
         dct[np.int64(12)] = 'some_string'
-    
+
 if __name__ == "__main__":
     T1 = TestTools()


### PR DESCRIPTION
Changes Summary
----------------
- pass through error messages of `json.dumps`
- try the `_serialize_value` helper before testing serializability
- added test


Reviewer Checklist
------------------
- [ ] Are testing routines present?
- [ ] Do objects in the global package namespace perform proper parsing of their input? 
- [ ] Are all docstrings complete and accurate?
- [ ] Is the CHANGELOG.md up to date?
